### PR TITLE
Add link for cPTX from github.

### DIFF
--- a/topo/node/cptx/cptx.go
+++ b/topo/node/cptx/cptx.go
@@ -1,4 +1,5 @@
 // Juniper cPTX for KNE
+// Copyright (c) Juniper Networks, Inc., 2021. All rights reserved.
 
 package cptx
 

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -47,6 +47,7 @@ import (
 	_ "github.com/google/kne/topo/node/quagga"
 	_ "github.com/google/kne/topo/node/srl"
 	_ "github.com/google/kne/topo/node/vmx"
+	_ "github.com/google/kne/topo/node/cptx"
 )
 
 // Manager is a topology instance manager for k8s cluster instance.


### PR DESCRIPTION
* This allows cPTX topo deployment from KNE's github repo.

* Added copyright string for cPTX per Juniper Legal team request.