### PR TITLE
Add reset config to nodes which support and add cli command

### DIFF
--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package deploy
 
 import (

--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package deploy
 
 import (

--- a/cmd/deploy/log_adaptor.go
+++ b/cmd/deploy/log_adaptor.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package deploy
 
 import (

--- a/cmd/deploy/specs.go
+++ b/cmd/deploy/specs.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package deploy
 
 import (

--- a/cmd/topology/topology.go
+++ b/cmd/topology/topology.go
@@ -72,8 +72,8 @@ var (
 )
 
 func resetCfgFn(cmd *cobra.Command, args []string) error {
-	if len(args) != 1 {
-		return fmt.Errorf("%s: missing args", cmd.Use)
+	if len(args) < 1 || len(args) > 2 {
+		return fmt.Errorf("%s: invalid args", cmd.Use)
 	}
 	topopb, err := topo.Load(args[0])
 	if err != nil {
@@ -99,18 +99,18 @@ func resetCfgFn(cmd *cobra.Command, args []string) error {
 		}
 		nodes = append(nodes, n)
 	}
-	var resetable []node.Reseter
+	var resettable []node.Resetter
 	for _, n := range nodes {
-		r, ok := n.Impl().(node.Reseter)
+		r, ok := n.Impl().(node.Resetter)
 		if !ok {
 			if skipReset {
 				continue
 			}
-			return fmt.Errorf("node %s is not resetable and --skip not set", n.Name())
+			return fmt.Errorf("node %s is not resettable and --skip not set", n.Name())
 		}
-		resetable = append(resetable, r)
+		resettable = append(resettable, r)
 	}
-	for _, r := range resetable {
+	for _, r := range resettable {
 		if err := r.ResetCfg(ctx); err != nil {
 			return err
 		}

--- a/cmd/topology/topology.go
+++ b/cmd/topology/topology.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package topology
 
 import (

--- a/cmd/topology/topology.go
+++ b/cmd/topology/topology.go
@@ -95,7 +95,7 @@ func resetCfgFn(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return err
 		}
-		nodes = append(nodes, n)
+		nodes = []*node.Node{n}
 	}
 	var resettable []node.Resetter
 	for _, n := range nodes {

--- a/cmd/topology/topology.go
+++ b/cmd/topology/topology.go
@@ -89,10 +89,8 @@ func resetCfgFn(cmd *cobra.Command, args []string) error {
 	}
 	ctx := cmd.Context()
 	t.Load(ctx)
-	var nodes []*node.Node
-	if len(args) == 1 {
-		nodes = t.Nodes()
-	} else {
+	nodes := t.Nodes()
+	if len(args) > 1 {
 		n, err := t.Node(args[1])
 		if err != nil {
 			return err

--- a/topo/node/ceos/ceos.go
+++ b/topo/node/ceos/ceos.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package ceos
 
 import (

--- a/topo/node/ceos/ceos_test.go
+++ b/topo/node/ceos/ceos_test.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package ceos
 
 import (

--- a/topo/node/cxr/cxr.go
+++ b/topo/node/cxr/cxr.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package cxr
 
 import (

--- a/topo/node/frr/frr.go
+++ b/topo/node/frr/frr.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package frr
 
 import (

--- a/topo/node/host/host.go
+++ b/topo/node/host/host.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package host
 
 import (

--- a/topo/node/node.go
+++ b/topo/node/node.go
@@ -44,15 +44,15 @@ type Implementation interface {
 
 type NewNodeFn func(*topopb.Node) (Implementation, error)
 
-// Reseter provides Reset interface to nodes.
-type Reseter interface {
+// Resetter provides Reset interface to nodes.
+type Resetter interface {
 	ResetCfg(context.Context) error
 }
 
 func (n *Node) ResetCfg(ctx context.Context) error {
-	r, ok := n.impl.(Reseter)
+	r, ok := n.impl.(Resetter)
 	if !ok {
-		return fmt.Errorf("%T is not a Reseter", n.impl)
+		return fmt.Errorf("%T is not a Resetter", n.impl)
 	}
 	return r.ResetCfg(ctx)
 }

--- a/topo/node/node.go
+++ b/topo/node/node.go
@@ -44,6 +44,19 @@ type Implementation interface {
 
 type NewNodeFn func(*topopb.Node) (Implementation, error)
 
+// Reseter provides Reset interface to nodes.
+type Reseter interface {
+	ResetCfg(context.Context) error
+}
+
+func (n *Node) ResetCfg(ctx context.Context) error {
+	r, ok := n.impl.(Reseter)
+	if !ok {
+		return fmt.Errorf("%T is not a Reseter", n.impl)
+	}
+	return r.ResetCfg(ctx)
+}
+
 var (
 	mu        sync.Mutex
 	nodeTypes = map[topopb.Node_Type]NewNodeFn{}

--- a/topo/node/quagga/quagga.go
+++ b/topo/node/quagga/quagga.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package quagga
 
 import (

--- a/topo/node/vmx/vmx.go
+++ b/topo/node/vmx/vmx.go
@@ -1,3 +1,16 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 package vmx
 
 import (

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"sort"
 	"sync"
 
 	"github.com/google/kne/topo/node"
@@ -286,6 +287,20 @@ type Resources struct {
 	Pods       map[string]*corev1.Pod
 	ConfigMaps map[string]*corev1.ConfigMap
 	Topologies map[string]*topologyv1.Topology
+}
+
+// Nodes returns all nodes in the current topology.
+func (m *Manager) Nodes() []*node.Node {
+	var keys []string
+	for k := range m.nodes {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	var n []*node.Node
+	for _, k := range keys {
+		n = append(n, m.nodes[k])
+	}
+	return n
 }
 
 // Resources gets the currently configured resources from the topology.


### PR DESCRIPTION
This adds 

kne_cli topology reset <config> <device>

to reset the configuration of the node to a default config

if no devices are provides all nodes in the topology will be attempted
--skip will skip nodes which don't support resetcfg but will continue through all nodes