### PR TITLE
draft fixup of scrapli failed/error setup

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/openconfig/gnmi v0.0.0-20210707145734-c69a5df04b53
 	github.com/pkg/errors v0.9.1
-	github.com/scrapli/scrapligo v0.0.0-20210822185345-c949ba367b79
+	github.com/scrapli/scrapligo v0.0.0-20210827224924-fcc0f67ff2a9
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/openconfig/gnmi v0.0.0-20210707145734-c69a5df04b53
 	github.com/pkg/errors v0.9.1
-	github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593
+	github.com/scrapli/scrapligo v0.1.0
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/go.mod
+++ b/go.mod
@@ -15,7 +15,7 @@ require (
 	github.com/morikuni/aec v1.0.0 // indirect
 	github.com/openconfig/gnmi v0.0.0-20210707145734-c69a5df04b53
 	github.com/pkg/errors v0.9.1
-	github.com/scrapli/scrapligo v0.0.0-20210827224924-fcc0f67ff2a9
+	github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593
 	github.com/sirupsen/logrus v1.8.1
 	github.com/spf13/cobra v1.1.3
 	github.com/spf13/pflag v1.0.5

--- a/go.sum
+++ b/go.sum
@@ -627,8 +627,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/scrapli/scrapligo v0.0.0-20210822185345-c949ba367b79 h1:fFnWvBZu5CLbZ5lKP7HJzOygxDQFWoDC6pVs1Yc44RQ=
-github.com/scrapli/scrapligo v0.0.0-20210822185345-c949ba367b79/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
+github.com/scrapli/scrapligo v0.0.0-20210827224924-fcc0f67ff2a9 h1:UbIoMVHdgLHUcU9dQToaEn2ZJCKOZ49dRWpm/5fyYpQ=
+github.com/scrapli/scrapligo v0.0.0-20210827224924-fcc0f67ff2a9/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/go.sum
+++ b/go.sum
@@ -627,8 +627,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/scrapli/scrapligo v0.0.0-20210827224924-fcc0f67ff2a9 h1:UbIoMVHdgLHUcU9dQToaEn2ZJCKOZ49dRWpm/5fyYpQ=
-github.com/scrapli/scrapligo v0.0.0-20210827224924-fcc0f67ff2a9/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
+github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593 h1:JAe+I0cjTpk4CIIWaFO5NaLIFkEuVsywlh4Yb9gzcnM=
+github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/go.sum
+++ b/go.sum
@@ -627,8 +627,8 @@ github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQD
 github.com/ryanuber/columnize v0.0.0-20160712163229-9b3edd62028f/go.mod h1:sm1tb6uqfes/u+d4ooFouqFdy9/2g9QGwK3SQygK0Ts=
 github.com/safchain/ethtool v0.0.0-20190326074333-42ed695e3de8/go.mod h1:Z0q5wiBQGYcxhMZ6gUqHn6pYNLypFAvaL3UvgZLR0U4=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
-github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593 h1:JAe+I0cjTpk4CIIWaFO5NaLIFkEuVsywlh4Yb9gzcnM=
-github.com/scrapli/scrapligo v0.0.0-20210828223731-aa2b82d0b593/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
+github.com/scrapli/scrapligo v0.1.0 h1:6bAtdQY9Phnacy811lf8kgoWqIMYAM/E3b5N07wVbyU=
+github.com/scrapli/scrapligo v0.1.0/go.mod h1:0tHMgiCiTuWOvSceFU7klaYThXvRZNvc7k+fmQrtH54=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=

--- a/topo/node/ceos/ceos.go
+++ b/topo/node/ceos/ceos.go
@@ -168,7 +168,9 @@ func (n *Node) GenerateSelfSigned(ctx context.Context, ni node.Interface) error 
 		return err
 	}
 
-	log.Infof("%s - finshed cert generation", n.pb.Name)
+	if resp.Failed == nil {
+		log.Infof("%s - finshed cert generation", n.pb.Name)
+	}
 
 	return resp.Failed
 }
@@ -197,7 +199,9 @@ func (n *Node) ConfigPush(ctx context.Context, ns string, r io.Reader) error {
 		return err
 	}
 
-	log.Infof("%s - finshed config push", n.pb.Name)
+	if resp.Failed == nil {
+		log.Infof("%s - finshed config push", n.pb.Name)
+	}
 
 	return resp.Failed
 }
@@ -221,7 +225,9 @@ func (n *Node) ResetCfg(ctx context.Context, ni node.Interface) error {
 		return err
 	}
 
-	log.Infof("%s - finshed resetting config", n.pb.Name)
+	if resp.Failed == nil {
+		log.Infof("%s - finshed resetting config", n.pb.Name)
+	}
 
 	return resp.Failed
 }

--- a/topo/node/ceos/ceos.go
+++ b/topo/node/ceos/ceos.go
@@ -76,7 +76,7 @@ func (n *Node) WaitCLIReady() error {
 
 // PatchCLIConnOpen sets the OpenCmd and ExecCmd of system transport to work with `kubectl exec` terminal.
 func (n *Node) PatchCLIConnOpen(ns string) error {
-	t, ok := interface{}(n.cliConn.Transport.Impl).(scraplitransport.SystemTransport)
+	t, ok := n.cliConn.Transport.Impl.(scraplitransport.SystemTransport)
 	if !ok {
 		return ErrIncompatibleCliConn
 	}

--- a/topo/node/ceos/ceos_test.go
+++ b/topo/node/ceos/ceos_test.go
@@ -132,7 +132,7 @@ func TestGenerateSelfSigned(t *testing.T) {
 			testFile: "generate_certificate_success",
 		},
 		{
-			// device returns "% Invalid Input" -- we expect to fail
+			// device returns "% Invalid input" -- we expect to fail
 			desc:     "failure",
 			wantErr:  true,
 			ni:       ni,
@@ -220,7 +220,7 @@ func TestResetCfg(t *testing.T) {
 			testFile: "reset_config_success",
 		},
 		{
-			// device returns "% Invalid Input" -- we expect to fail
+			// device returns "% Invalid input" -- we expect to fail
 			desc:     "failure",
 			wantErr:  true,
 			ni:       ni,

--- a/topo/node/ceos/generate_certificate_failure
+++ b/topo/node/ceos/generate_certificate_failure
@@ -9,7 +9,7 @@ spine1#configure terminal
 spine1(config)#
 spine1(config)#security pki key generate rsa 2048 my_key
 spine1(config)#security pki certificate generate self-signed my_cert key my_key parameters common-name pod1
-% Invalid Input
+% Invalid input
 spine1(config)#
 spine1(config)#end
 spine1#

--- a/topo/node/ceos/reset_config_failure
+++ b/topo/node/ceos/reset_config_failure
@@ -21,7 +21,7 @@ Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet20 h
 Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet18 has been added to instance MST0
 Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet17 has been added to instance MST0
 Aug 21 18:37:16 localhost Stp: %SPANTREE-6-INTERFACE_ADD: Interface Ethernet9 has been added to instance MST0
-% Invalid Input
+% Invalid input
 spine1#
 spine1#
 spine1#


### PR DESCRIPTION
- no more bleeding in of the test helper (created an interface for system transport and then just let the test transport implement that so we are always good with test and with "real" transport)
- `Failed` is an error now rather than a bool so we can just return that directly
- currently pinned to branch im working on doing some cleanup on so just a draft for now, but if this looks good will update pin once that branch gets merged

@hellt @marcushines 