### PR TITLE
Control GCE zone with cloudbuild substitution

### DIFF
--- a/cloudbuild/cloudbuild.yaml
+++ b/cloudbuild/cloudbuild.yaml
@@ -15,9 +15,17 @@ steps:
   - id: packer_build
     name: "gcr.io/gep-kne/packer"
     args: ["build", "cloudbuild/ubuntu.pkr.hcl"]
-    env: ["PKR_VAR_build_id=$BUILD_ID", "PKR_VAR_short_sha=$SHORT_SHA", "PKR_VAR_branch_name=$BRANCH_NAME"]
+    env: [
+      "PKR_VAR_build_id=$BUILD_ID",
+      "PKR_VAR_short_sha=$SHORT_SHA",
+      "PKR_VAR_branch_name=$BRANCH_NAME",
+      "PKR_VAR_zone=${_ZONE}",
+    ]
 
 timeout: 1800s
+
+substitutions:
+  _ZONE: us-central1-b # default value
 
 options:
   pool:

--- a/cloudbuild/ubuntu.pkr.hcl
+++ b/cloudbuild/ubuntu.pkr.hcl
@@ -10,6 +10,11 @@ variable "build_id" {
   type = string
 }
 
+variable "zone" {
+  type = string
+  default = "us-central1-b"
+}
+
 source "googlecompute" "kne-image" {
   project_id   = "gep-kne"
   source_image = "ubuntu-2004-focal-v20210927"
@@ -24,8 +29,8 @@ source "googlecompute" "kne-image" {
   }
   image_description     = "Ubuntu based linux VM image with KNE and all dependencies installed."
   ssh_username          = "user"
-  machine_type          = "n2-standard-8"
-  zone                  = "us-central1-a"
+  machine_type          = "e2-medium"
+  zone                  = "${var.zone}"
   service_account_email = "packer@gep-kne.iam.gserviceaccount.com"
   use_internal_ip       = true
   scopes                = ["https://www.googleapis.com/auth/cloud-platform"]


### PR DESCRIPTION
Fixes issues with machine quota, gives more control to the build requestor.