### PR TITLE
Fix kubectl exec commands

### DIFF
--- a/topo/node/cptx/cptx.go
+++ b/topo/node/cptx/cptx.go
@@ -101,7 +101,7 @@ func (n *Node) PatchCLIConnOpen(ns string) error {
 	if n.Kubecfg != "" {
 		args = append(args, fmt.Sprintf("--kubeconfig=%s", n.Kubecfg))
 	}
-	args = append(args, "exec", "-it", "-n", n.Namespace, n.Name(), "--", "Cli")
+	args = append(args, "exec", "-it", "-n", n.Namespace, n.Name(), "--", "cli", "-c")
 	t.SetOpenCmd(args)
 
 	return nil

--- a/topo/node/srl/srl.go
+++ b/topo/node/srl/srl.go
@@ -272,7 +272,7 @@ func (n *Node) PatchCLIConnOpen(ns string) error {
 	if n.Kubecfg != "" {
 		args = append(args, fmt.Sprintf("--kubeconfig=%s", n.Kubecfg))
 	}
-	args = append(args, "-it", "-n", n.Namespace, n.Name(), "--", "Cli")
+	args = append(args, "exec", "-it", "-n", n.Namespace, n.Name(), "--", "sr_cli", "-d")
 	t.SetOpenCmd(args)
 
 	return nil


### PR DESCRIPTION
#99 modified the Nokia SRL CLI command with incorrect syntax.  I do not have a CPTX image to test against but it looks like it was modified the same way.