### PR TITLE
Extract the logics of create/delete topology into topo.go

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -130,7 +130,6 @@ func createFn(cmd *cobra.Command, args []string) error {
 		Kubecfg:        kubecfg,
 		TopoNewFunc:    topo.New,
 		TopoNewOptions: []topo.Option{topo.WithBasePath(bp)},
-		TopoLoadFunc:   topo.Load,
 		Timeout:        timeout,
 		DryRun:         dryrun,
 	}
@@ -142,7 +141,6 @@ func deleteFn(cmd *cobra.Command, args []string) error {
 		TopoName:     args[0],
 		Kubecfg:      kubecfg,
 		TopoNewFunc:  topo.New,
-		TopoLoadFunc: topo.Load,
 	}
 	return topo.DeleteTopology(cmd.Context(), p)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -21,7 +21,6 @@ import (
 	"path/filepath"
 	"time"
 
-	"github.com/golang/protobuf/proto"
 	"github.com/google/kne/cmd/deploy"
 	"github.com/google/kne/cmd/topology"
 	"github.com/google/kne/topo"
@@ -114,6 +113,7 @@ func validateTopology(cmd *cobra.Command, args []string) error {
 
 var (
 	topoNew = topo.New
+	topoLoad = topo.Load
 )
 
 func fileRelative(p string) (string, error) {
@@ -125,68 +125,31 @@ func fileRelative(p string) (string, error) {
 }
 
 func createFn(cmd *cobra.Command, args []string) error {
-	topopb, err := topo.Load(args[0])
-	if err != nil {
-		return fmt.Errorf("%s: %w", cmd.Use, err)
-	}
 	bp, err := fileRelative(args[0])
 	if err != nil {
 		return err
 	}
-	fmt.Println(bp)
-	t, err := topoNew(kubecfg, topopb, topo.WithBasePath(bp))
-	if err != nil {
-		return fmt.Errorf("%s: %w", cmd.Use, err)
+	log.Infof(bp)
+	p := topo.TopologyParams {
+		TopoName: args[0],
+		Kubecfg: kubecfg,
+		TopoNewFunc: topoNew,
+		TopoNewOptions: []topo.Option{topo.WithBasePath(bp)},
+		TopoLoadFunc: topoLoad,
+		Timeout: timeout,
+		DryRun: dryrun,
 	}
-	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "Topology:\n%s\n", proto.MarshalTextString(topopb))
-	if err := t.Load(cmd.Context()); err != nil {
-		return fmt.Errorf("failed to load topology: %w", err)
-	}
-	if dryrun {
-		return nil
-	}
-	if err := t.Push(cmd.Context()); err != nil {
-		return err
-	}
-	if err := t.CheckNodeStatus(cmd.Context(), timeout); err != nil {
-		return err
-	}
-	fmt.Fprintf(out, "Topology %q created\n", topopb.Name)
-	r, err := t.Resources(cmd.Context())
-	if err != nil {
-		return fmt.Errorf("%s: %w", cmd.Use, err)
-	}
-	fmt.Fprintf(out, "Pods:\n")
-	for _, p := range r.Pods {
-		fmt.Fprintf(out, "%s\n", p.Name)
-	}
-
-	return nil
+	return topo.CreateTopology(cmd.Context(), p)
 }
 
 func deleteFn(cmd *cobra.Command, args []string) error {
-	topopb, err := topo.Load(args[0])
-	if err != nil {
-		return fmt.Errorf("%s: %w", cmd.Use, err)
+	p := topo.TopologyParams {
+		TopoName: args[0],
+		Kubecfg: kubecfg,
+		TopoNewFunc: topoNew,
+		TopoLoadFunc: topoLoad,
 	}
-	t, err := topo.New(kubecfg, topopb)
-	if err != nil {
-		return fmt.Errorf("%s: %w", cmd.Use, err)
-	}
-	out := cmd.OutOrStdout()
-	fmt.Fprintf(out, "Topology:\n%s\n", proto.MarshalTextString(topopb))
-	if err := t.Load(cmd.Context()); err != nil {
-		return fmt.Errorf("failed to load topology: %w", err)
-	}
-	if dryrun {
-		return nil
-	}
-	if err := t.Delete(cmd.Context()); err != nil {
-		return err
-	}
-	fmt.Fprintf(out, "Successfully deleted topology: %q\n", topopb.Name)
-	return nil
+	return topo.DeleteTopology(cmd.Context(), p)
 }
 
 func showFn(cmd *cobra.Command, args []string) error {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -111,11 +111,6 @@ func validateTopology(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-var (
-	topoNew = topo.New
-	topoLoad = topo.Load
-)
-
 func fileRelative(p string) (string, error) {
 	bp, err := filepath.Abs(p)
 	if err != nil {
@@ -130,24 +125,24 @@ func createFn(cmd *cobra.Command, args []string) error {
 		return err
 	}
 	log.Infof(bp)
-	p := topo.TopologyParams {
-		TopoName: args[0],
-		Kubecfg: kubecfg,
-		TopoNewFunc: topoNew,
+	p := topo.TopologyParams{
+		TopoName:       args[0],
+		Kubecfg:        kubecfg,
+		TopoNewFunc:    topo.New,
 		TopoNewOptions: []topo.Option{topo.WithBasePath(bp)},
-		TopoLoadFunc: topoLoad,
-		Timeout: timeout,
-		DryRun: dryrun,
+		TopoLoadFunc:   topo.Load,
+		Timeout:        timeout,
+		DryRun:         dryrun,
 	}
 	return topo.CreateTopology(cmd.Context(), p)
 }
 
 func deleteFn(cmd *cobra.Command, args []string) error {
-	p := topo.TopologyParams {
-		TopoName: args[0],
-		Kubecfg: kubecfg,
-		TopoNewFunc: topoNew,
-		TopoLoadFunc: topoLoad,
+	p := topo.TopologyParams{
+		TopoName:     args[0],
+		Kubecfg:      kubecfg,
+		TopoNewFunc:  topo.New,
+		TopoLoadFunc: topo.Load,
 	}
 	return topo.DeleteTopology(cmd.Context(), p)
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -128,7 +128,6 @@ func createFn(cmd *cobra.Command, args []string) error {
 	p := topo.TopologyParams{
 		TopoName:       args[0],
 		Kubecfg:        kubecfg,
-		TopoNewFunc:    topo.New,
 		TopoNewOptions: []topo.Option{topo.WithBasePath(bp)},
 		Timeout:        timeout,
 		DryRun:         dryrun,
@@ -138,9 +137,8 @@ func createFn(cmd *cobra.Command, args []string) error {
 
 func deleteFn(cmd *cobra.Command, args []string) error {
 	p := topo.TopologyParams{
-		TopoName:     args[0],
-		Kubecfg:      kubecfg,
-		TopoNewFunc:  topo.New,
+		TopoName: args[0],
+		Kubecfg:  kubecfg,
 	}
 	return topo.DeleteTopology(cmd.Context(), p)
 }

--- a/topo/testdata/invalid_topo.pb.txt
+++ b/topo/testdata/invalid_topo.pb.txt
@@ -1,0 +1,11 @@
+name: "test-data-topology"
+nodes: {
+    name: "r1"
+    type: ARISTA_CEOS
+}
+links: {
+    a_node: "r1"
+    a_int: "eth9"
+    z_node: "ate1"
+    z_int: "eth1"
+}

--- a/topo/testdata/valid_topo.pb.txt
+++ b/topo/testdata/valid_topo.pb.txt
@@ -1,0 +1,28 @@
+name: "test-data-topology"
+nodes: {
+    name: "r1"
+    type: ARISTA_CEOS
+}
+nodes: {
+    name: "ate1"
+    type: IXIA_TG
+    version: "0.0.1-9999"
+    services: {
+        key: 5555
+        value: {
+            inside: 5555
+        }
+    }
+    services: {
+        key: 50071
+        value: {
+            inside: 50071
+        }
+    }
+}
+links: {
+    a_node: "r1"
+    a_int: "eth9"
+    z_node: "ate1"
+    z_int: "eth1"
+}

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/google/kne/topo/node"
+  "github.com/golang/protobuf/proto"
 	"github.com/kr/pretty"
 	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc/codes"
@@ -444,4 +445,76 @@ func (m *Manager) Node(nodeName string) (node.Node, error) {
 		return nil, fmt.Errorf("node %q not found", nodeName)
 	}
 	return n, nil
+}
+
+// TopologyParams specifies the parameters used by the functions that
+// creates/deletes topology.
+type TopologyParams struct {
+	TopoName       string                                                   // the filename of the topology
+	Kubecfg        string                                                   // the path of kube config
+	TopoLoadFunc   func(fName string) (*tpb.Topology, error)                // the function that returns the topology protobuf from a file
+	TopoNewFunc    func(string, *tpb.Topology, ...Option) (*Manager, error) // the function that returns a Manager with the topology protobuf
+	TopoNewOptions []Option                                                 // the options used in the TopoNewFunc
+	Timeout        time.Duration
+	DryRun         bool
+}
+
+// CreateTopology creates the topology and configs it.
+func CreateTopology(ctx context.Context, params TopologyParams) error {
+	topopb, err := params.TopoLoadFunc(params.TopoName)
+	if err != nil {
+		return fmt.Errorf("failed to load %s: %+v", params.TopoName, err)
+	}
+	t, err := params.TopoNewFunc(params.Kubecfg, topopb, params.TopoNewOptions...)
+	if err != nil {
+		return fmt.Errorf("failed to create topology for %s: %+v", params.TopoName, err)
+	}
+	log.Infof("Topology:\n%s\n", proto.MarshalTextString(topopb))
+	if err := t.Load(ctx); err != nil {
+		return fmt.Errorf("failed to load topology: %w", err)
+	}
+	if params.DryRun {
+		return nil
+	}
+
+	if err := t.Push(ctx); err != nil {
+		return err
+	}
+	if err := t.CheckNodeStatus(ctx, params.Timeout); err != nil {
+		return err
+	}
+	log.Infof("Topology %q created\n", topopb.Name)
+	r, err := t.Resources(ctx)
+	if err != nil {
+		return fmt.Errorf("failed to check resource %s: %+v", params.TopoName, err)
+	}
+	log.Infof("Pods:")
+	for _, p := range r.Pods {
+		log.Infof("%s\n", p.Name)
+	}
+
+	return nil
+}
+
+// DeleteTopology deletes the topology.
+func DeleteTopology(ctx context.Context, params TopologyParams) error {
+	topopb, err := params.TopoLoadFunc(params.TopoName)
+	if err != nil {
+		return fmt.Errorf("failed to load %s: %+v", params.TopoName, err)
+	}
+	t, err := params.TopoNewFunc(params.Kubecfg, topopb, params.TopoNewOptions...)
+	if err != nil {
+		return fmt.Errorf("failed to delete topology for %s: %+v", params.TopoName, err)
+	}
+	log.Infof("Topology:\n%+v\n", proto.MarshalTextString(topopb))
+	if err := t.Load(ctx); err != nil {
+		return fmt.Errorf("failed to load %s: %+v", params.TopoName, err)
+	}
+
+	if err := t.Delete(ctx); err != nil {
+		return fmt.Errorf("failed to delete %s: %+v", params.TopoName, err)
+	}
+	log.Infof("Successfully deleted topology: %q", topopb.Name)
+
+	return nil
 }

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -456,10 +456,9 @@ func (m *Manager) Node(nodeName string) (node.Node, error) {
 // TopologyParams specifies the parameters used by the functions that
 // creates/deletes topology.
 type TopologyParams struct {
-	TopoName       string                                                   // the filename of the topology
-	Kubecfg        string                                                   // the path of kube config
-	TopoNewFunc    func(string, *tpb.Topology, ...Option) (*Manager, error) // the function that returns a Manager with the topology protobuf
-	TopoNewOptions []Option                                                 // the options used in the TopoNewFunc
+	TopoName       string   // the filename of the topology
+	Kubecfg        string   // the path of kube config
+	TopoNewOptions []Option // the options used in the TopoNewFunc
 	Timeout        time.Duration
 	DryRun         bool
 }
@@ -470,7 +469,7 @@ func CreateTopology(ctx context.Context, params TopologyParams) error {
 	if err != nil {
 		return fmt.Errorf("failed to load %s: %+v", params.TopoName, err)
 	}
-	t, err := params.TopoNewFunc(params.Kubecfg, topopb, params.TopoNewOptions...)
+	t, err := New(params.Kubecfg, topopb, params.TopoNewOptions...)
 	if err != nil {
 		return fmt.Errorf("failed to create topology for %s: %+v", params.TopoName, err)
 	}
@@ -507,7 +506,7 @@ func DeleteTopology(ctx context.Context, params TopologyParams) error {
 	if err != nil {
 		return fmt.Errorf("failed to load %s: %+v", params.TopoName, err)
 	}
-	t, err := params.TopoNewFunc(params.Kubecfg, topopb, params.TopoNewOptions...)
+	t, err := New(params.Kubecfg, topopb, params.TopoNewOptions...)
 	if err != nil {
 		return fmt.Errorf("failed to delete topology for %s: %+v", params.TopoName, err)
 	}

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -40,7 +40,6 @@ func TestCreateTopology(t *testing.T) {
 	tests := []struct {
 		desc       string
 		inputParam TopologyParams
-		testFunc   func(ctx context.Context, params TopologyParams) error
 		wantErr    string
 	}{{
 		desc: "create with valid topology file",
@@ -98,7 +97,6 @@ func TestDeleteTopology(t *testing.T) {
 	tests := []struct {
 		desc       string
 		inputParam TopologyParams
-		testFunc   func(ctx context.Context, params TopologyParams) error
 		wantErr    string
 	}{{
 		desc: "delete a non-existing topology with valid topology file",

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -16,11 +16,9 @@ package topo
 
 import (
 	"context"
-	// "fmt"
 	"testing"
 
 	tfake "github.com/google/kne/api/clientset/v1beta1/fake"
-	// tpb "github.com/google/kne/proto/topo"
 	"github.com/h-fam/errdiff"
 	kfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -16,11 +16,11 @@ package topo
 
 import (
 	"context"
-	"fmt"
+	// "fmt"
 	"testing"
 
 	tfake "github.com/google/kne/api/clientset/v1beta1/fake"
-	tpb "github.com/google/kne/proto/topo"
+	// tpb "github.com/google/kne/proto/topo"
 	"github.com/h-fam/errdiff"
 	kfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
@@ -45,7 +45,6 @@ func TestCreateTopology(t *testing.T) {
 		desc: "create with valid topology file",
 		inputParam: TopologyParams{
 			TopoName:       "testdata/valid_topo.pb.txt",
-			TopoNewFunc:    New,
 			TopoNewOptions: opts,
 			DryRun:         true,
 		},
@@ -54,7 +53,6 @@ func TestCreateTopology(t *testing.T) {
 		desc: "create with non-existent topology file",
 		inputParam: TopologyParams{
 			TopoName:       "testdata/non_existing.pb.txt",
-			TopoNewFunc:    New,
 			TopoNewOptions: opts,
 			DryRun:         true,
 		},
@@ -62,10 +60,7 @@ func TestCreateTopology(t *testing.T) {
 	}, {
 		desc: "create with invalid topology",
 		inputParam: TopologyParams{
-			TopoName: "testdata/valid_topo.pb.txt",
-			TopoNewFunc: func(string, *tpb.Topology, ...Option) (*Manager, error) {
-				return nil, fmt.Errorf("invalid topology")
-			},
+			TopoName:       "testdata/invalid_topo.pb.txt",
 			TopoNewOptions: opts,
 			DryRun:         true,
 		},
@@ -102,7 +97,6 @@ func TestDeleteTopology(t *testing.T) {
 		desc: "delete a non-existing topology with valid topology file",
 		inputParam: TopologyParams{
 			TopoName:       "testdata/valid_topo.pb.txt",
-			TopoNewFunc:    New,
 			TopoNewOptions: opts,
 			DryRun:         true,
 		},
@@ -111,7 +105,6 @@ func TestDeleteTopology(t *testing.T) {
 		desc: "delete with non-existent topology file",
 		inputParam: TopologyParams{
 			TopoName:       "testdata/non_existing.pb.txt",
-			TopoNewFunc:    New,
 			TopoNewOptions: opts,
 			DryRun:         true,
 		},
@@ -119,10 +112,7 @@ func TestDeleteTopology(t *testing.T) {
 	}, {
 		desc: "delete with invalid topology",
 		inputParam: TopologyParams{
-			TopoName: "testdata/valid_topo.pb.txt",
-			TopoNewFunc: func(string, *tpb.Topology, ...Option) (*Manager, error) {
-				return nil, fmt.Errorf("invalid topology")
-			},
+			TopoName:       "testdata/invalid_topo.pb.txt",
 			TopoNewOptions: opts,
 			DryRun:         true,
 		},

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -1,0 +1,135 @@
+// Copyright 2021 Google LLC
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package topo
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	tfake "github.com/google/kne/api/clientset/v1beta1/fake"
+	tpb "github.com/google/kne/proto/topo"
+	"github.com/h-fam/errdiff"
+	kfake "k8s.io/client-go/kubernetes/fake"
+
+	"k8s.io/client-go/rest"
+)
+
+var (
+	opts []Option
+)
+
+func TestCreateDeletTopology(t *testing.T) {
+	origOpts := opts
+	tf, err := tfake.NewSimpleClientset()
+	if err != nil {
+		t.Fatalf("cannot create fake topology clientset")
+	}
+	opts = []Option{
+		WithClusterConfig(&rest.Config{}),
+		WithKubeClient(kfake.NewSimpleClientset()),
+		WithTopoClient(tf),
+	}
+	defer func() {
+		opts = origOpts
+	}()
+
+	tests := []struct {
+		desc       string
+		inputParam TopologyParams
+		testFunc   func(ctx context.Context, params TopologyParams) error
+		wantErr    string
+	}{{
+		desc: "create with valid topology file",
+		inputParam: TopologyParams{
+			TopoName:       "testdata/valid_topo.pb.txt",
+			TopoLoadFunc:   Load,
+			TopoNewFunc:    New,
+			TopoNewOptions: opts,
+			DryRun:         true,
+		},
+		testFunc: CreateTopology,
+		wantErr:  "",
+	}, {
+		desc: "create with non-existent topology file",
+		inputParam: TopologyParams{
+			TopoName:       "testdata/non_existing.pb.txt",
+			TopoLoadFunc:   Load,
+			TopoNewFunc:    New,
+			TopoNewOptions: opts,
+			DryRun:         true,
+		},
+		testFunc: CreateTopology,
+		wantErr:  "no such file or directory",
+	}, {
+		desc: "create with invalid topology",
+		inputParam: TopologyParams{
+			TopoLoadFunc: func(fName string) (*tpb.Topology, error) {
+				return &tpb.Topology{}, nil
+			},
+			TopoNewFunc: func(string, *tpb.Topology, ...Option) (*Manager, error) {
+				return nil, fmt.Errorf("invalid topology")
+			},
+			TopoNewOptions: opts,
+			DryRun:         true,
+		},
+		testFunc: CreateTopology,
+		wantErr:  "invalid topology",
+	}, {
+		desc: "delete a non-existing topology with valid topology file",
+		inputParam: TopologyParams{
+			TopoName:       "testdata/valid_topo.pb.txt",
+			TopoLoadFunc:   Load,
+			TopoNewFunc:    New,
+			TopoNewOptions: opts,
+			DryRun:         true,
+		},
+		testFunc: DeleteTopology,
+		wantErr:  "does not exist in cluster",
+	}, {
+		desc: "delete with non-existent topology file",
+		inputParam: TopologyParams{
+			TopoName:       "testdata/non_existing.pb.txt",
+			TopoLoadFunc:   Load,
+			TopoNewFunc:    New,
+			TopoNewOptions: opts,
+			DryRun:         true,
+		},
+		testFunc: DeleteTopology,
+		wantErr:  "no such file or directory",
+	}, {
+		desc: "delete with invalid topology",
+		inputParam: TopologyParams{
+			TopoLoadFunc: func(fName string) (*tpb.Topology, error) {
+				return &tpb.Topology{}, nil
+			},
+			TopoNewFunc: func(string, *tpb.Topology, ...Option) (*Manager, error) {
+				return nil, fmt.Errorf("invalid topology")
+			},
+			TopoNewOptions: opts,
+			DryRun:         true,
+		},
+		testFunc: DeleteTopology,
+		wantErr:  "invalid topology",
+	},
+	}
+
+	for _, tc := range tests {
+		err := tc.testFunc(context.Background(), tc.inputParam)
+		if diff := errdiff.Check(err, tc.wantErr); diff != "" {
+			t.Fatalf("[%s] failed: %+v", tc.desc, err)
+		}
+	}
+}


### PR DESCRIPTION
This is the first step of refactoring kne_cli library by making
the code reusable for the Topology manager service.

Test
==
* Unit tests are added.
* Compiled and ran the refactored kne_cli in the GCE VM
  (with the order of create/show/delete), compared its output
  with the same parameters/steps with current kne_cli, and
  the output were consistent.