### PR TITLE
Extract the logics of "show topology service" into topo.go

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -14,7 +14,7 @@ jobs:
     - name: Set up Go
       uses: actions/setup-go@v2.1.3
       with:
-        go-version: 1.16.7
+        go-version: 1.17.7
     - name: Build
       run: go build -v ./...
   test:

--- a/cloudbuild/ubuntu.pkr.hcl
+++ b/cloudbuild/ubuntu.pkr.hcl
@@ -43,9 +43,9 @@ build {
   provisioner "shell" {
     inline = [
       "echo Installing golang...",
-      "curl -O https://dl.google.com/go/go1.16.5.linux-amd64.tar.gz",
-      "sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.16.5.linux-amd64.tar.gz",
-      "rm go1.16.5.linux-amd64.tar.gz",
+      "curl -O https://dl.google.com/go/go1.17.7.linux-amd64.tar.gz",
+      "sudo rm -rf /usr/local/go && sudo tar -C /usr/local -xzf go1.17.7.linux-amd64.tar.gz",
+      "rm go1.17.7.linux-amd64.tar.gz",
       "echo 'export PATH=$PATH:/usr/local/go/bin' >> ~/.bashrc",
       "echo 'export PATH=$PATH:$(go env GOPATH)/bin' >> ~/.bashrc",
       "/usr/local/go/bin/go version",
@@ -90,6 +90,9 @@ build {
       "sudo apt-get install git -y",
       "git clone -b ${var.branch_name} https://github.com/google/kne.git",
       "cd kne/kne_cli",
+      "/usr/local/go/bin/go build -v",
+      "cp kne_cli /usr/local/bin/",
+      "cd ../controller/server",
       "/usr/local/go/bin/go build -v",
     ]
   }

--- a/cloudbuild/ubuntu.pkr.hcl
+++ b/cloudbuild/ubuntu.pkr.hcl
@@ -91,7 +91,7 @@ build {
       "git clone -b ${var.branch_name} https://github.com/google/kne.git",
       "cd kne/kne_cli",
       "/usr/local/go/bin/go build -v",
-      "cp kne_cli /usr/local/bin/",
+      "sudo cp kne_cli /usr/local/bin/",
       "cd ../controller/server",
       "/usr/local/go/bin/go build -v",
     ]

--- a/cloudbuild/ubuntu.pkr.hcl
+++ b/cloudbuild/ubuntu.pkr.hcl
@@ -71,6 +71,7 @@ build {
     inline = [
       "echo Installing kind...",
       "/usr/local/go/bin/go get -u sigs.k8s.io/kind",
+      "sudo cp /home/$USER/go/bin/kind /usr/local/bin/",
       "/home/$USER/go/bin/kind version",
     ]
   }

--- a/cmd/deploy/deploy.go
+++ b/cmd/deploy/deploy.go
@@ -20,10 +20,10 @@ import (
 	"os/exec"
 	"path/filepath"
 
+	"github.com/google/kne/deploy"
 	log "github.com/sirupsen/logrus"
 	"github.com/spf13/cobra"
 	"gopkg.in/yaml.v3"
-	"github.com/google/kne/deploy"
 )
 
 func New() *cobra.Command {
@@ -36,18 +36,18 @@ func New() *cobra.Command {
 }
 
 type ClusterSpec struct {
-        Kind string    `yaml:"kind"`
-        Spec yaml.Node `yaml:"spec"`
+	Kind string    `yaml:"kind"`
+	Spec yaml.Node `yaml:"spec"`
 }
 
 type IngressSpec struct {
-        Kind string    `yaml:"kind"`
-        Spec yaml.Node `yaml:"spec"`
+	Kind string    `yaml:"kind"`
+	Spec yaml.Node `yaml:"spec"`
 }
 
 type CNISpec struct {
-        Kind string    `yaml:"kind"`
-        Spec yaml.Node `yaml:"spec"`
+	Kind string    `yaml:"kind"`
+	Spec yaml.Node `yaml:"spec"`
 }
 
 type DeploymentConfig struct {

--- a/cmd/topology/topology_test.go
+++ b/cmd/topology/topology_test.go
@@ -319,10 +319,10 @@ links: {
   z_int: "eth1"
 }
 links: {
-    a_node: "r1"
-    a_int: "eth9"
-    z_node: "ate2"
-    z_int: "eth1"
+  a_node: "r1"
+  a_int: "eth9"
+  z_node: "ate2"
+  z_int: "eth1"
 }
 `
 )

--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -21,9 +21,9 @@ import (
 	"os"
 	"path/filepath"
 
+	log "github.com/golang/glog"
 	"github.com/google/kne/deploy"
 	cpb "github.com/google/kne/proto/controller"
-	log "github.com/sirupsen/logrus"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/alts"
 	"k8s.io/client-go/util/homedir"
@@ -106,11 +106,12 @@ func newDeployment(req *cpb.CreateClusterRequest) (*deploy.Deployment, error) {
 }
 
 func (s *server) CreateCluster(ctx context.Context, req *cpb.CreateClusterRequest) (*cpb.CreateClusterResponse, error) {
-	log.Infof("Creating new cluster")
+	log.Infof("Received CreateCluster request: %+v", req)
 	d, err := newDeployment(req)
 	if err != nil {
 		return nil, err
 	}
+	log.Infof("Parsed request into deployment: %+v", d)
 	if err := d.Deploy(ctx, defaultKubeCfg); err != nil {
 		resp := &cpb.CreateClusterResponse{
 			Name:  req.GetKind().Name,
@@ -147,7 +148,7 @@ func main() {
 	creds := alts.NewServerCreds(alts.DefaultServerOptions())
 	s := grpc.NewServer(grpc.Creds(creds))
 	cpb.RegisterTopologyManagerServer(s, &server{})
-	log.Printf("Controller server listening at %v", lis.Addr())
+	log.Infof("Controller server listening at %v", lis.Addr())
 	if err := s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)
 	}

--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -31,9 +31,10 @@ import (
 
 var (
 	defaultKubeCfg            = ""
-	port                      = flag.Int("port", 50051, "Controller server port")
 	defaultMetallbManifestDir = ""
 	defaultMeshnetManifestDir = ""
+	// Flags.
+	port = flag.Int("port", 50051, "Controller server port")
 )
 
 func init() {
@@ -59,6 +60,7 @@ func newDeployment(req *cpb.CreateClusterRequest) (*deploy.Deployment, error) {
 			Image:                    req.GetKind().Image,
 			Retain:                   req.GetKind().Retain,
 			GoogleArtifactRegistries: req.GetKind().GoogleArtifactRegistries,
+			ContainerImages:          req.GetKind().ContainerImages,
 		}
 	default:
 		return nil, fmt.Errorf("cluster type not supported: %T", kind)
@@ -116,7 +118,7 @@ func (s *server) CreateCluster(ctx context.Context, req *cpb.CreateClusterReques
 		}
 		return resp, fmt.Errorf("failed to deploy cluster: %s", err)
 	}
-	log.Infof("Cluster: %q deployed and ready for topology.", req.GetKind().Name)
+	log.Infof("Cluster %q deployed and ready for topology", req.GetKind().Name)
 	resp := &cpb.CreateClusterResponse{
 		Name:  req.GetKind().Name,
 		State: cpb.ClusterState_CLUSTER_STATE_RUNNING,

--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -26,8 +26,8 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/client-go/util/homedir"
 
-	// "google.golang.org/grpc/credentials/alts"
 	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/alts"
 )
 
 var (
@@ -143,9 +143,8 @@ func main() {
 	if err != nil {
 		log.Fatalf("failed to listen: %v", err)
 	}
-	// creds := alts.NewServerCreds(alts.DefaultServerOptions())
-	// s := grpc.NewServer(grpc.Creds(creds))
-	s := grpc.NewServer()
+	creds := alts.NewServerCreds(alts.DefaultServerOptions())
+	s := grpc.NewServer(grpc.Creds(creds))
 	cpb.RegisterTopologyManagerServer(s, &server{})
 	log.Printf("Controller server listening at %v", lis.Addr())
 	if err := s.Serve(lis); err != nil {

--- a/controller/server/main_test.go
+++ b/controller/server/main_test.go
@@ -1,0 +1,94 @@
+package main
+
+import (
+	"testing"
+
+	cpb "github.com/google/kne/proto/controller"
+	"github.com/h-fam/errdiff"
+)
+
+func TestGetDeployment(t *testing.T) {
+
+	tests := []struct {
+		desc    string
+		req     *cpb.CreateClusterRequest
+		wantErr string
+	}{{
+		desc: "full request spec",
+		req: &cpb.CreateClusterRequest{
+			ClusterSpec: &cpb.CreateClusterRequest_Kind{
+				&cpb.KindSpec{
+					Name:    "kne",
+					Recycle: true,
+					Version: "0.11.1",
+					Image:   "kindest/node:v1.22.1",
+				},
+			},
+			IngressSpec: &cpb.CreateClusterRequest_Metallb{
+				&cpb.MetallbSpec{
+					ManifestDir: "../../foo",
+					IpCount:     100,
+				},
+			},
+			CniSpec: &cpb.CreateClusterRequest_Meshnet{
+				&cpb.MeshnetSpec{
+					ManifestDir: "../../bar",
+				},
+			},
+		},
+	}, {
+		desc:    "empty kind spec",
+		req:     &cpb.CreateClusterRequest{},
+		wantErr: "cluster type not supported:",
+	}, {
+		desc: "empty ingress spec",
+		req: &cpb.CreateClusterRequest{
+			ClusterSpec: &cpb.CreateClusterRequest_Kind{
+				&cpb.KindSpec{
+					Name:    "kne",
+					Recycle: true,
+					Version: "0.11.1",
+					Image:   "kindest/node:v1.22.1",
+				},
+			},
+			CniSpec: &cpb.CreateClusterRequest_Meshnet{
+				&cpb.MeshnetSpec{
+					ManifestDir: "../../bar",
+				},
+			},
+		},
+		wantErr: "ingress spec not supported:",
+	}, {
+		desc: "empty Cni spec",
+		req: &cpb.CreateClusterRequest{
+			ClusterSpec: &cpb.CreateClusterRequest_Kind{
+				&cpb.KindSpec{
+					Name:    "kne",
+					Recycle: true,
+					Version: "0.11.1",
+					Image:   "kindest/node:v1.22.1",
+				},
+			},
+			IngressSpec: &cpb.CreateClusterRequest_Metallb{
+				&cpb.MetallbSpec{
+					ManifestDir: "../../foo",
+					IpCount:     100,
+				},
+			},
+		},
+		wantErr: "CNI type not supported:",
+	}}
+	for _, tt := range tests {
+		t.Run(tt.desc, func(t *testing.T) {
+			d, err := getDeployment(tt.req)
+			if s := errdiff.Substring(err, tt.wantErr); s != "" {
+				t.Fatalf("unexpected error: %s", s)
+			}
+			if err != nil {
+				return
+			}
+			t.Log(d)
+		})
+	}
+
+}

--- a/controller/server/main_test.go
+++ b/controller/server/main_test.go
@@ -25,11 +25,14 @@ func TestNewDeployment(t *testing.T) {
 			},
 			IngressSpec: &cpb.CreateClusterRequest_Metallb{
 				&cpb.MetallbSpec{
-					IpCount: 100,
+					ManifestDir: "/home",
+					IpCount:     100,
 				},
 			},
 			CniSpec: &cpb.CreateClusterRequest_Meshnet{
-				&cpb.MeshnetSpec{},
+				&cpb.MeshnetSpec{
+					ManifestDir: "/home",
+				},
 			},
 		},
 	}, {
@@ -98,7 +101,7 @@ func TestNewDeployment(t *testing.T) {
 				},
 			},
 		},
-		wantErr: "failed to validate path \"/foo\"",
+		wantErr: "failed to validate path",
 	}, {
 		desc: "cni spec empty",
 		req: &cpb.CreateClusterRequest{

--- a/controller/server/main_test.go
+++ b/controller/server/main_test.go
@@ -8,7 +8,6 @@ import (
 )
 
 func TestNewDeployment(t *testing.T) {
-
 	tests := []struct {
 		desc    string
 		req     *cpb.CreateClusterRequest

--- a/controller/server/main_test.go
+++ b/controller/server/main_test.go
@@ -99,6 +99,25 @@ func TestNewDeployment(t *testing.T) {
 			},
 		},
 		wantErr: "failed to validate path \"/foo\"",
+	}, {
+		desc: "cni spec empty",
+		req: &cpb.CreateClusterRequest{
+			ClusterSpec: &cpb.CreateClusterRequest_Kind{
+				&cpb.KindSpec{
+					Name:    "kne",
+					Recycle: true,
+					Version: "0.11.1",
+					Image:   "kindest/node:v1.22.1",
+				},
+			},
+			IngressSpec: &cpb.CreateClusterRequest_Metallb{
+				&cpb.MetallbSpec{
+					ManifestDir: "/usr/local",
+					IpCount:     100,
+				},
+			},
+		},
+		wantErr: "cni type not supported:",
 	}}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -285,6 +285,7 @@ func (k *KindSpec) loadContainerImages() error {
 		return errors.Wrap(err, "install docker cli to load container images")
 	}
 	for s, d := range k.ContainerImages {
+		log.Infof("Loading %q as %q", s, d)
 		if err := execer.Exec("docker", "pull", s); err != nil {
 			return errors.Wrapf(err, "pulling %q", s)
 		}
@@ -299,7 +300,7 @@ func (k *KindSpec) loadContainerImages() error {
 			return errors.Wrapf(err, "loading %q", d)
 		}
 	}
-	log.Infof("Loaded all container images %v", k.ContainerImages)
+	log.Infof("Loaded all container images")
 	return nil
 }
 

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -132,16 +132,16 @@ func (d *Deployment) Deploy(ctx context.Context, kubecfg string) error {
 }
 
 type KindSpec struct {
-	Name                     string        `yaml:"name"`
-	Recycle                  bool          `yaml:"recycle"`
-	Version                  string        `yaml:"version"`
-	Image                    string        `yaml:"image"`
-	Retain                   bool          `yaml:"retain"`
-	Wait                     time.Duration `yaml:"wait"`
-	Kubecfg                  string        `yaml:"kubecfg"`
-	DeployWithClient         bool          `yaml:"deployWithClient"`
-	GoogleArtifactRegistries []string      `yaml:"googleArtifactRegistries"`
-	ContainerImages map[string]string `yaml:"containerImages"`
+	Name                     string            `yaml:"name"`
+	Recycle                  bool              `yaml:"recycle"`
+	Version                  string            `yaml:"version"`
+	Image                    string            `yaml:"image"`
+	Retain                   bool              `yaml:"retain"`
+	Wait                     time.Duration     `yaml:"wait"`
+	Kubecfg                  string            `yaml:"kubecfg"`
+	DeployWithClient         bool              `yaml:"deployWithClient"`
+	GoogleArtifactRegistries []string          `yaml:"googleArtifactRegistries"`
+	ContainerImages          map[string]string `yaml:"containerImages"`
 }
 
 func (k *KindSpec) Deploy(ctx context.Context) error {
@@ -270,7 +270,7 @@ func (k *KindSpec) setupGoogleArtifactRegistryAccess() error {
 	for _, node := range strings.Split(nodes.String(), " ") {
 		node = strings.TrimSuffix(node, "\n")
 		if err := execer.Exec("docker", "cp", configPath, fmt.Sprintf(kubeletConfigPathTemplate, node)); err != nil {
-                        return err
+			return err
 		}
 		if err := execer.Exec("docker", "exec", node, "systemctl", "restart", "kubelet.service"); err != nil {
 			return err
@@ -287,17 +287,17 @@ func (k *KindSpec) loadContainerImages() error {
 	for s, d := range k.ContainerImages {
 		if err := execer.Exec("docker", "pull", s); err != nil {
 			return errors.Wrapf(err, "pulling %q", s)
-                }
+		}
 		if err := execer.Exec("docker", "tag", s, d); err != nil {
-                        return errors.Wrapf(err, "tagging %q with %q", s, d)
-                }
+			return errors.Wrapf(err, "tagging %q with %q", s, d)
+		}
 		args := []string{"load", "docker-image", d}
 		if k.Name != "" {
 			args = append(args, "--name", k.Name)
 		}
 		if err := execer.Exec("kind", args...); err != nil {
-                        return errors.Wrapf(err, "loading %q", d)
-                }
+			return errors.Wrapf(err, "loading %q", d)
+		}
 	}
 	log.Infof("Loaded all container images %v", k.ContainerImages)
 	return nil

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -174,17 +174,17 @@ func TestKindSpec(t *testing.T) {
 	}, {
 		desc: "create cluster load containers",
 		k: &KindSpec{
-			Name:                     "test",
+			Name: "test",
 			ContainerImages: map[string]string{
 				"docker": "local",
-				"gar": "docker",
+				"gar":    "docker",
 			},
 		},
-		execer:  exec.NewFakeExecer(nil, nil, nil, nil, nil, nil, nil),
+		execer: exec.NewFakeExecer(nil, nil, nil, nil, nil, nil, nil),
 	}, {
 		desc: "create cluster load containers - failed pull",
 		k: &KindSpec{
-			Name:                     "test",
+			Name: "test",
 			ContainerImages: map[string]string{
 				"docker": "local",
 			},
@@ -194,7 +194,7 @@ func TestKindSpec(t *testing.T) {
 	}, {
 		desc: "create cluster load containers - failed tag",
 		k: &KindSpec{
-			Name:                     "test",
+			Name: "test",
 			ContainerImages: map[string]string{
 				"docker": "local",
 			},
@@ -204,7 +204,7 @@ func TestKindSpec(t *testing.T) {
 	}, {
 		desc: "create cluster load containers - failed load",
 		k: &KindSpec{
-			Name:                     "test",
+			Name: "test",
 			ContainerImages: map[string]string{
 				"docker": "local",
 			},
@@ -214,8 +214,8 @@ func TestKindSpec(t *testing.T) {
 	}, {
 		desc: "create cluster load containers - requires CLI",
 		k: &KindSpec{
-			Name:                     "test",
-			DeployWithClient:         true,
+			Name:             "test",
+			DeployWithClient: true,
 			ContainerImages: map[string]string{
 				"docker": "local",
 			},

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -171,6 +171,57 @@ func TestKindSpec(t *testing.T) {
 		},
 		execer:  exec.NewFakeExecer(nil),
 		wantErr: "requires unsetting the deployWithClient field",
+	}, {
+		desc: "create cluster load containers",
+		k: &KindSpec{
+			Name:                     "test",
+			ContainerImages: map[string]string{
+				"docker": "local",
+				"gar": "docker",
+			},
+		},
+		execer:  exec.NewFakeExecer(nil, nil, nil, nil, nil, nil, nil),
+	}, {
+		desc: "create cluster load containers - failed pull",
+		k: &KindSpec{
+			Name:                     "test",
+			ContainerImages: map[string]string{
+				"docker": "local",
+			},
+		},
+		execer:  exec.NewFakeExecer(nil, errors.New("unable to pull")),
+		wantErr: "pulling",
+	}, {
+		desc: "create cluster load containers - failed tag",
+		k: &KindSpec{
+			Name:                     "test",
+			ContainerImages: map[string]string{
+				"docker": "local",
+			},
+		},
+		execer:  exec.NewFakeExecer(nil, nil, errors.New("unable to tag")),
+		wantErr: "tagging",
+	}, {
+		desc: "create cluster load containers - failed load",
+		k: &KindSpec{
+			Name:                     "test",
+			ContainerImages: map[string]string{
+				"docker": "local",
+			},
+		},
+		execer:  exec.NewFakeExecer(nil, nil, nil, errors.New("unable to load")),
+		wantErr: "loading",
+	}, {
+		desc: "create cluster load containers - requires CLI",
+		k: &KindSpec{
+			Name:                     "test",
+			DeployWithClient:         true,
+			ContainerImages: map[string]string{
+				"docker": "local",
+			},
+		},
+		execer:  exec.NewFakeExecer(nil),
+		wantErr: "requires unsetting the deployWithClient field",
 	}}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {

--- a/deploy/log_adaptor.go
+++ b/deploy/log_adaptor.go
@@ -60,4 +60,3 @@ func (l *logAdapter) V(level klog.Level) klog.InfoLogger {
 	}
 	return &debugLogger{l.Logger}
 }
-

--- a/go.mod
+++ b/go.mod
@@ -4,6 +4,7 @@ go 1.17
 
 require (
 	github.com/docker/docker v20.10.11+incompatible
+	github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.2
 	github.com/google/go-cmp v0.5.6

--- a/go.sum
+++ b/go.sum
@@ -328,6 +328,7 @@ github.com/gogo/protobuf v1.3.0/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXP
 github.com/gogo/protobuf v1.3.1/go.mod h1:SlYgWuQ5SjCEi6WLHjHCa1yvBfUnHcTbrrZtXPKa29o=
 github.com/gogo/protobuf v1.3.2 h1:Ov1cvc58UF3b5XjBnZv7+opcTcQFZebYjWzi34vdm4Q=
 github.com/gogo/protobuf v1.3.2/go.mod h1:P1XiOD3dCwIKUDQYPy72D8LYyHL2YPYrpS2s69NZV8Q=
+github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b h1:VKtxabqXZkF25pY9ekfRL6a582T4P37/31XEstQ5p58=
 github.com/golang/glog v0.0.0-20160126235308-23def4e6c14b/go.mod h1:SBH7ygxi8pfUlaOkMMuAQtPIUF8ecWP5IEl/CR7VP2Q=
 github.com/golang/groupcache v0.0.0-20160516000752-02826c3e7903/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=
 github.com/golang/groupcache v0.0.0-20190129154638-5b532d6fd5ef/go.mod h1:cIg4eruTrX1D+g88fzRXU5OdNfaM+9IcxsU14FzY7Hc=

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -508,6 +508,26 @@ func (m *Manager) Node(nodeName string) (node.Node, error) {
 	return n, nil
 }
 
+type resourcer interface {
+	Load(context.Context) error
+	Resources(context.Context) (*Resources, error)
+}
+
+// fakeTopology is used for testing only.
+type fakeTopology struct {
+	resources *Resources
+	rErr      error
+	lErr      error
+}
+
+func (f *fakeTopology) Load(context.Context) error {
+	return f.lErr
+}
+
+func (f *fakeTopology) Resources(context.Context) (*Resources, error) {
+	return f.resources, f.rErr
+}
+
 // TopologyParams specifies the parameters used by the functions that
 // creates/deletes/show topology.
 type TopologyParams struct {
@@ -516,6 +536,7 @@ type TopologyParams struct {
 	TopoNewOptions []Option // the options used in the TopoNewFunc
 	Timeout        time.Duration
 	DryRun         bool
+	fakeTopo       *fakeTopology // a fake topology manager for testing only
 }
 
 // CreateTopology creates the topology and configs it.

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -508,26 +508,6 @@ func (m *Manager) Node(nodeName string) (node.Node, error) {
 	return n, nil
 }
 
-type resourcer interface {
-	Load(context.Context) error
-	Resources(context.Context) (*Resources, error)
-}
-
-// fakeTopology is used for testing only.
-type fakeTopology struct {
-	resources *Resources
-	rErr      error
-	lErr      error
-}
-
-func (f *fakeTopology) Load(context.Context) error {
-	return f.lErr
-}
-
-func (f *fakeTopology) Resources(context.Context) (*Resources, error) {
-	return f.resources, f.rErr
-}
-
 // TopologyParams specifies the parameters used by the functions that
 // creates/deletes/show topology.
 type TopologyParams struct {
@@ -536,7 +516,6 @@ type TopologyParams struct {
 	TopoNewOptions []Option // the options used in the TopoNewFunc
 	Timeout        time.Duration
 	DryRun         bool
-	fakeTopo       *fakeTopology // a fake topology manager for testing only
 }
 
 // CreateTopology creates the topology and configs it.

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -49,6 +49,61 @@ import (
 	_ "github.com/google/kne/topo/node/srl"
 )
 
+// Resourcer loads and reports resources of a topology.
+type Resourcer interface {
+	Load(context.Context) error
+	Resources(context.Context) (*Resources, error)
+}
+
+// Creator creates a topology.
+type Creator interface {
+	Load(context.Context) error
+	Push(context.Context) error
+	CheckNodeStatus(context.Context, time.Duration) error
+	Resources(context.Context) (*Resources, error)
+}
+
+// Deleter deletes a topology.
+type Deleter interface {
+	Load(context.Context) error
+	Delete(context.Context) error
+}
+
+// Watcher watches a topology.
+type Watcher interface {
+	Watch(context.Context) error
+}
+
+// Pusher pushes config to a topology.
+type Pusher interface {
+	Load(context.Context) error
+	Push(context.Context) error
+	ConfigPush(context.Context, string, io.Reader) error
+}
+
+// Certer generates cert for a node.
+type Certer interface {
+	Load(context.Context) error
+	Node(string) (node.Node, error)
+}
+
+// Resetter reset a topology.
+type Resetter interface {
+	Load(context.Context) error
+	Nodes() []node.Node
+}
+
+// TopologyManager manages a topology.
+type TopologyManager interface {
+	Resourcer
+	Creator
+	Deleter
+	Watcher
+	Pusher
+	Certer
+	Resetter
+}
+
 // Manager is a topology instance manager for k8s cluster instance.
 type Manager struct {
 	BasePath string
@@ -93,7 +148,7 @@ func WithBasePath(s string) Option {
 }
 
 // New creates a new topology manager based on the provided kubecfg and topology.
-func New(kubecfg string, pb *tpb.Topology, opts ...Option) (*Manager, error) {
+func New(kubecfg string, pb *tpb.Topology, opts ...Option) (TopologyManager, error) {
 	if pb == nil {
 		return nil, fmt.Errorf("pb cannot be nil")
 	}
@@ -453,35 +508,14 @@ func (m *Manager) Node(nodeName string) (node.Node, error) {
 	return n, nil
 }
 
-type resourcer interface {
-	Load(context.Context) error
-	Resources(context.Context) (*Resources, error)
-}
-
-// fakeTopology is used for testing only.
-type fakeTopology struct {
-	resources *Resources
-	rErr      error
-	lErr      error
-}
-
-func (f *fakeTopology) Load(context.Context) error {
-	return f.lErr
-}
-
-func (f *fakeTopology) Resources(context.Context) (*Resources, error) {
-	return f.resources, f.rErr
-}
-
 // TopologyParams specifies the parameters used by the functions that
-// creates/deletes topology.
+// creates/deletes/show topology.
 type TopologyParams struct {
 	TopoName       string   // the filename of the topology
 	Kubecfg        string   // the path of kube config
 	TopoNewOptions []Option // the options used in the TopoNewFunc
 	Timeout        time.Duration
 	DryRun         bool
-	fakeTopo       *fakeTopology // a fake topology manager for testing only
 }
 
 // CreateTopology creates the topology and configs it.
@@ -573,6 +607,10 @@ func serviceToProto(s *corev1.Service, m map[uint32]*tpb.Service) error {
 	return nil
 }
 
+var (
+	new = New // a non-public new to allow overriding the New() in this package.
+)
+
 // GetTopologyServices returns the topology information.
 func GetTopologyServices(ctx context.Context, params TopologyParams) (*tpb.Topology, error) {
 	topopb, err := Load(params.TopoName)
@@ -580,15 +618,11 @@ func GetTopologyServices(ctx context.Context, params TopologyParams) (*tpb.Topol
 		return nil, fmt.Errorf("failed to load %s: %+v", params.TopoName, err)
 	}
 
-	var t resourcer
-	if params.fakeTopo != nil {
-		t = params.fakeTopo
-	} else {
-		t, err = New(params.Kubecfg, topopb, params.TopoNewOptions...)
-		if err != nil {
-			return nil, fmt.Errorf("failed to get topology service for %s: %+v", params.TopoName, err)
-		}
+	t, err := new(params.Kubecfg, topopb, params.TopoNewOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get topology service for %s: %+v", params.TopoName, err)
 	}
+
 	if err := t.Load(ctx); err != nil {
 		return nil, fmt.Errorf("failed to load %s: %+v", params.TopoName, err)
 	}

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -16,12 +16,92 @@ package topo
 
 import (
 	"context"
+	"fmt"
 	"testing"
 
 	tfake "github.com/google/kne/api/clientset/v1beta1/fake"
+	tpb "github.com/google/kne/proto/topo"
 	"github.com/h-fam/errdiff"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	kfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
+)
+
+var (
+	validPbTxt = `
+name: "test-data-topology"
+nodes: {
+  name: "r1"
+  type: ARISTA_CEOS
+  services: {
+	key: 1002
+	value: {
+  name: "ssh"
+	  inside: 1002
+	  outside: 22
+	  inside_ip: "1.1.1.2"
+	  outside_ip: "100.100.100.101"
+	  node_port: 22
+	}
+  }
+}
+nodes: {
+  name: "ate1"
+  type: IXIA_TG
+  services: {
+	key: 1000
+	value: {
+	  name: "gnmi"
+	  inside: 1000
+	  inside_ip: "1.1.1.1"
+	  outside_ip: "100.100.100.100"
+	  node_port: 20000
+	}
+  }
+  services: {
+	key: 1001
+	value: {
+	  name: "grpc"
+	  inside: 1001
+	  inside_ip: "1.1.1.1"
+	  outside_ip: "100.100.100.100"
+	  node_port: 20001
+	}
+  }
+  services: {
+	key: 5555
+	value: {
+	  name: "port-5555"
+	  inside: 5555
+	  outside: 5555
+	  inside_ip: "1.1.1.3"
+	  outside_ip: "100.100.100.102"
+	  node_port: 30010
+	}
+  }
+  services: {
+	key: 50071
+	value: {
+	  name: "port-50071"
+	  inside: 50071
+	  outside: 50071
+	  inside_ip: "1.1.1.3"
+	  outside_ip: "100.100.100.102"
+	  node_port: 30011
+	}
+  }
+  version: "0.0.1-9999"
+}
+links: {
+  a_node: "r1"
+  a_int: "eth9"
+  z_node: "ate1"
+  z_int: "eth1"
+}
+`
 )
 
 func TestCreateTopology(t *testing.T) {
@@ -123,6 +203,156 @@ func TestDeleteTopology(t *testing.T) {
 			err := DeleteTopology(context.Background(), tc.inputParam)
 			if diff := errdiff.Check(err, tc.wantErr); diff != "" {
 				t.Fatalf("failed: %+v", err)
+			}
+		})
+	}
+}
+
+func TestGetTopologyServices(t *testing.T) {
+	tf, err := tfake.NewSimpleClientset()
+	if err != nil {
+		t.Fatalf("cannot create fake topology clientset")
+	}
+	opts := []Option{
+		WithClusterConfig(&rest.Config{}),
+		WithKubeClient(kfake.NewSimpleClientset()),
+		WithTopoClient(tf),
+	}
+	validTopoOut := &tpb.Topology{}
+	if err := prototext.Unmarshal([]byte(validPbTxt), validTopoOut); err != nil {
+		t.Fatalf("cannot Unmarshal validTopo: %v", err)
+	}
+	tests := []struct {
+		desc       string
+		inputParam TopologyParams
+		want       *tpb.Topology
+		wantErr    string
+	}{{
+		desc: "load topology error",
+		inputParam: TopologyParams{
+			TopoName:       "testdata/not_there.pb.txt",
+			TopoNewOptions: opts,
+			fakeTopo: &fakeTopology{
+				resources: &Resources{},
+			},
+		},
+		wantErr: "no such file or directory",
+	}, {
+		desc: "empty resources",
+		inputParam: TopologyParams{
+			TopoName:       "testdata/valid_topo.pb.txt",
+			TopoNewOptions: opts,
+			fakeTopo: &fakeTopology{
+				resources: &Resources{},
+			},
+		},
+		wantErr: "not found",
+	}, {
+		desc: "load fail",
+		inputParam: TopologyParams{
+			TopoName:       "testdata/valid_topo.pb.txt",
+			TopoNewOptions: opts,
+			fakeTopo: &fakeTopology{
+				lErr:      fmt.Errorf("load failed"),
+				resources: &Resources{},
+			},
+		},
+		wantErr: "load failed",
+	}, {
+		desc: "valid case",
+		inputParam: TopologyParams{
+			TopoName:       "testdata/valid_topo.pb.txt",
+			TopoNewOptions: opts,
+			fakeTopo: &fakeTopology{
+				resources: &Resources{
+					Services: map[string]*corev1.Service{
+						"gnmi-service": {
+							Spec: corev1.ServiceSpec{
+								ClusterIP: "1.1.1.1",
+								Ports: []corev1.ServicePort{{
+									Port:     1000,
+									NodePort: 20000,
+									Name:     "gnmi",
+								}},
+							},
+							Status: corev1.ServiceStatus{
+								LoadBalancer: corev1.LoadBalancerStatus{
+									Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.100"}},
+								},
+							},
+						},
+						"grpc-service": {
+							Spec: corev1.ServiceSpec{
+								ClusterIP: "1.1.1.1",
+								Ports: []corev1.ServicePort{{
+									Port:     1001,
+									NodePort: 20001,
+									Name:     "grpc",
+								}},
+							},
+							Status: corev1.ServiceStatus{
+								LoadBalancer: corev1.LoadBalancerStatus{
+									Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.100"}},
+								},
+							},
+						},
+						"service-r1": {
+							Spec: corev1.ServiceSpec{
+								ClusterIP: "1.1.1.2",
+								Ports: []corev1.ServicePort{{
+									Port:       1002,
+									NodePort:   22,
+									Name:       "ssh",
+									TargetPort: intstr.IntOrString{IntVal: 22},
+								}},
+							},
+							Status: corev1.ServiceStatus{
+								LoadBalancer: corev1.LoadBalancerStatus{
+									Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.101"}},
+								},
+							},
+						},
+						"service-ate1": {
+							Spec: corev1.ServiceSpec{
+								ClusterIP: "1.1.1.3",
+								Ports: []corev1.ServicePort{{
+									Port:       5555,
+									NodePort:   30010,
+									Name:       "port-5555",
+									TargetPort: intstr.IntOrString{IntVal: 5555},
+								}, {
+									Port:       50071,
+									NodePort:   30011,
+									Name:       "port-50071",
+									TargetPort: intstr.IntOrString{IntVal: 50071},
+								}},
+							},
+							Status: corev1.ServiceStatus{
+								LoadBalancer: corev1.LoadBalancerStatus{
+									Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.102"}},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		wantErr: "",
+		want:    validTopoOut,
+	},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			got, err := GetTopologyServices(context.Background(), tc.inputParam)
+			if diff := errdiff.Check(err, tc.wantErr); diff != "" {
+				t.Fatalf("failed: %+v", err)
+			}
+			if tc.wantErr != "" {
+				return
+			}
+			if !proto.Equal(got, tc.want) {
+				t.Fatalf("get topology service failed: got:\n%s\n, want:\n%s\n", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR extracts the logics of kne_cli's "show topology service" into GetTopologyServices() in topo.go.

Test
==
- Unit tests are added for both topo/topo_test.go and cmd/topology/topology_test.go.
- Compiled and ran the refactored kne_cli in the GCE VM, compared its output with the same parameters with current kne_cli, and the output were consistent.