### PR TITLE
Extract the logics of "show topology service" into topo.go

### DIFF
--- a/cmd/topology/topology_test.go
+++ b/cmd/topology/topology_test.go
@@ -17,8 +17,6 @@ import (
 	"github.com/h-fam/errdiff"
 	"google.golang.org/protobuf/encoding/prototext"
 	"google.golang.org/protobuf/proto"
-	corev1 "k8s.io/api/core/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
 	kfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 
@@ -249,20 +247,6 @@ func TestReset(t *testing.T) {
 	}
 }
 
-type fakeTopology struct {
-	resources *topo.Resources
-	rErr      error
-	lErr      error
-}
-
-func (f *fakeTopology) Load(context.Context) error {
-	return f.lErr
-}
-
-func (f *fakeTopology) Resources(context.Context) (*topo.Resources, error) {
-	return f.resources, f.rErr
-}
-
 var (
 	validPbTxt = `
 name: "test-data-topology"
@@ -339,146 +323,56 @@ links: {
   a_int: "eth9"
   z_node: "ate2"
   z_int: "eth1"
-}	
+}
 `
 )
 
 func TestService(t *testing.T) {
-	sCmd := New()
-	origOpts := opts
-	defer func() {
-		opts = origOpts
-	}()
-	sCmd.PersistentFlags().String("kubecfg", "", "")
-	buf := bytes.NewBuffer([]byte{})
-	sCmd.SetOut(buf)
-	validTopoOut := &tpb.Topology{}
-	if err := prototext.Unmarshal([]byte(validPbTxt), validTopoOut); err != nil {
-		t.Fatalf("cannot Unmarshal validTopo: %v", err)
+	validProto := &tpb.Topology{}
+	if err := prototext.Unmarshal([]byte(validPbTxt), validProto); err != nil {
+		t.Fatalf("failed to build a valid Topology protobuf for testing: %v", err)
 	}
 	tests := []struct {
-		desc    string
-		args    []string
-		tFile   string
-		want    *tpb.Topology
-		wantErr string
-		topoNew func(string, *tpb.Topology, ...topo.Option) (resourcer, error)
-	}{{
-		desc:    "no args",
-		wantErr: "missing topology",
-		args:    []string{"service"},
-	}, {
-		desc:    "empty resources",
-		wantErr: "not found",
-		args:    []string{"service", "testdata/valid_topo.pb.txt"},
-		topoNew: func(string, *tpb.Topology, ...topo.Option) (resourcer, error) {
-			return &fakeTopology{
-				resources: &topo.Resources{},
-			}, nil
+		desc                string
+		args                []string
+		getTopologyServices func(ctx context.Context, params topo.TopologyParams) (*tpb.Topology, error)
+		want                *tpb.Topology
+		wantErr             string
+	}{
+		{
+			desc:    "no args",
+			wantErr: "missing topology",
+			args:    []string{"service"},
+		}, {
+			desc: "fail to get topology service",
+			getTopologyServices: func(context.Context, topo.TopologyParams) (*tpb.Topology, error) {
+				return nil, fmt.Errorf("some error")
+			},
+			wantErr: "some error",
+			args:    []string{"service", "testdata/valid_topo.pb.txt"},
+		}, {
+			desc: "valid case",
+			getTopologyServices: func(context.Context, topo.TopologyParams) (*tpb.Topology, error) {
+				return validProto, nil
+			},
+			want: validProto,
+			args: []string{"service", "testdata/valid_topo.pb.txt"},
 		},
-	}, {
-		desc:    "Load fail",
-		wantErr: "load failed",
-		args:    []string{"service", "testdata/valid_topo.pb.txt"},
-		topoNew: func(string, *tpb.Topology, ...topo.Option) (resourcer, error) {
-			return &fakeTopology{
-				lErr:      fmt.Errorf("load failed"),
-				resources: &topo.Resources{},
-			}, nil
-		},
-	}, {
-		desc: "newTopo valid",
-		args: []string{"service", "testdata/valid_topo.pb.txt"},
-		want: validTopoOut,
-		topoNew: func(string, *tpb.Topology, ...topo.Option) (resourcer, error) {
-			return &fakeTopology{
-				resources: &topo.Resources{
-					Services: map[string]*corev1.Service{
-						"gnmi-service": {
-							Spec: corev1.ServiceSpec{
-								ClusterIP: "1.1.1.1",
-								Ports: []corev1.ServicePort{{
-									Port:     1000,
-									NodePort: 20000,
-									Name:     "gnmi",
-								}},
-							},
-							Status: corev1.ServiceStatus{
-								LoadBalancer: corev1.LoadBalancerStatus{
-									Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.100"}},
-								},
-							},
-						},
-						"grpc-service": {
-							Spec: corev1.ServiceSpec{
-								ClusterIP: "1.1.1.1",
-								Ports: []corev1.ServicePort{{
-									Port:     1001,
-									NodePort: 20001,
-									Name:     "grpc",
-								}},
-							},
-							Status: corev1.ServiceStatus{
-								LoadBalancer: corev1.LoadBalancerStatus{
-									Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.100"}},
-								},
-							},
-						},
-						"service-r1": {
-							Spec: corev1.ServiceSpec{
-								ClusterIP: "1.1.1.2",
-								Ports: []corev1.ServicePort{{
-									Port:       1002,
-									NodePort:   22,
-									Name:       "ssh",
-									TargetPort: intstr.IntOrString{IntVal: 22},
-								}},
-							},
-							Status: corev1.ServiceStatus{
-								LoadBalancer: corev1.LoadBalancerStatus{
-									Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.101"}},
-								},
-							},
-						},
-						"service-ate1": {
-							Spec: corev1.ServiceSpec{
-								ClusterIP: "1.1.1.3",
-								Ports: []corev1.ServicePort{{
-									Port:       5555,
-									NodePort:   30010,
-									Name:       "port-5555",
-									TargetPort: intstr.IntOrString{IntVal: 5555},
-								}, {
-									Port:       50071,
-									NodePort:   30011,
-									Name:       "port-50071",
-									TargetPort: intstr.IntOrString{IntVal: 50071},
-								}},
-							},
-							Status: corev1.ServiceStatus{
-								LoadBalancer: corev1.LoadBalancerStatus{
-									Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.102"}},
-								},
-							},
-						},
-					},
-				},
-			}, nil
-		},
-	}, {
-		desc:    "load topo error",
-		wantErr: "no such file or directory",
-		args:    []string{"service", "dne.txt"},
-	}}
+	}
+
+	sCmd := New()
+	sCmd.PersistentFlags().String("kubecfg", "", "")
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
+			origGetTopologyServices := getTopologyServices
+			getTopologyServices = tt.getTopologyServices
+			defer func() {
+				getTopologyServices = origGetTopologyServices
+			}()
 			buf := bytes.NewBuffer([]byte{})
 			sCmd.SetOut(buf)
 			sCmd.SetArgs(tt.args)
-			topoNew = tt.topoNew
-			defer func() {
-				topoNew = defaultNewTopo
-			}()
+
 			err := sCmd.ExecuteContext(context.Background())
 			if s := errdiff.Check(err, tt.wantErr); s != "" {
 				t.Fatalf("serviceCmd failed: %s", s)

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -49,59 +49,17 @@ import (
 	_ "github.com/google/kne/topo/node/srl"
 )
 
-// Resourcer loads and reports resources of a topology.
-type Resourcer interface {
-	Load(context.Context) error
-	Resources(context.Context) (*Resources, error)
-}
-
-// Creator creates a topology.
-type Creator interface {
-	Load(context.Context) error
-	Push(context.Context) error
-	CheckNodeStatus(context.Context, time.Duration) error
-	Resources(context.Context) (*Resources, error)
-}
-
-// Deleter deletes a topology.
-type Deleter interface {
-	Load(context.Context) error
-	Delete(context.Context) error
-}
-
-// Watcher watches a topology.
-type Watcher interface {
-	Watch(context.Context) error
-}
-
-// Pusher pushes config to a topology.
-type Pusher interface {
-	Load(context.Context) error
-	Push(context.Context) error
-	ConfigPush(context.Context, string, io.Reader) error
-}
-
-// Certer generates cert for a node.
-type Certer interface {
-	Load(context.Context) error
-	Node(string) (node.Node, error)
-}
-
-// Resetter reset a topology.
-type Resetter interface {
-	Load(context.Context) error
-	Nodes() []node.Node
-}
-
 // TopologyManager manages a topology.
 type TopologyManager interface {
-	Resourcer
-	Creator
-	Deleter
-	Watcher
-	Pusher
-	Certer
-	Resetter
+	CheckNodeStatus(context.Context, time.Duration) error
+	ConfigPush(context.Context, string, io.Reader) error
+	Delete(context.Context) error
+	Load(context.Context) error
+	Node(string) (node.Node, error)
+	Nodes() []node.Node
+	Push(context.Context) error
+	Resources(context.Context) (*Resources, error)
+	Watch(context.Context) error
 }
 
 // Manager is a topology instance manager for k8s cluster instance.

--- a/topo/topo.go
+++ b/topo/topo.go
@@ -49,6 +49,61 @@ import (
 	_ "github.com/google/kne/topo/node/srl"
 )
 
+// Resourcer loads and reports resources of a topology.
+type Resourcer interface {
+	Load(context.Context) error
+	Resources(context.Context) (*Resources, error)
+}
+
+// Creator creates a topology.
+type Creator interface {
+	Load(context.Context) error
+	Push(context.Context) error
+	CheckNodeStatus(context.Context, time.Duration) error
+	Resources(context.Context) (*Resources, error)
+}
+
+// Deleter deletes a topology.
+type Deleter interface {
+	Load(context.Context) error
+	Delete(context.Context) error
+}
+
+// Watcher watches a topology.
+type Watcher interface {
+	Watch(context.Context) error
+}
+
+// Pusher pushes config to a topology.
+type Pusher interface {
+	Load(context.Context) error
+	Push(context.Context) error
+	ConfigPush(context.Context, string, io.Reader) error
+}
+
+// Certer generates cert for a node.
+type Certer interface {
+	Load(context.Context) error
+	Node(string) (node.Node, error)
+}
+
+// Resetter reset a topology.
+type Resetter interface {
+	Load(context.Context) error
+	Nodes() []node.Node
+}
+
+// TopologyManager manages a topology.
+type TopologyManager interface {
+	Resourcer
+	Creator
+	Deleter
+	Watcher
+	Pusher
+	Certer
+	Resetter
+}
+
 // Manager is a topology instance manager for k8s cluster instance.
 type Manager struct {
 	BasePath string
@@ -93,7 +148,7 @@ func WithBasePath(s string) Option {
 }
 
 // New creates a new topology manager based on the provided kubecfg and topology.
-func New(kubecfg string, pb *tpb.Topology, opts ...Option) (*Manager, error) {
+func New(kubecfg string, pb *tpb.Topology, opts ...Option) (TopologyManager, error) {
 	if pb == nil {
 		return nil, fmt.Errorf("pb cannot be nil")
 	}
@@ -454,7 +509,7 @@ func (m *Manager) Node(nodeName string) (node.Node, error) {
 }
 
 // TopologyParams specifies the parameters used by the functions that
-// creates/deletes topology.
+// creates/deletes/show topology.
 type TopologyParams struct {
 	TopoName       string   // the filename of the topology
 	Kubecfg        string   // the path of kube config
@@ -521,4 +576,84 @@ func DeleteTopology(ctx context.Context, params TopologyParams) error {
 	log.Infof("Successfully deleted topology: %q", topopb.Name)
 
 	return nil
+}
+
+// serviceToProto creates the service mapping.
+func serviceToProto(s *corev1.Service, m map[uint32]*tpb.Service) error {
+	if s == nil || m == nil {
+		return fmt.Errorf("service and map must not be nil")
+	}
+	if len(s.Status.LoadBalancer.Ingress) == 0 {
+		return fmt.Errorf("service %s has no external loadbalancer configured", s.Name)
+	}
+	for _, p := range s.Spec.Ports {
+		k := uint32(p.Port)
+		service, ok := m[k]
+		if !ok {
+			service = &tpb.Service{
+				Name:   p.Name,
+				Inside: k,
+			}
+			m[k] = service
+		}
+		if service.Name == "" {
+			service.Name = p.Name
+		}
+		service.Outside = uint32(p.TargetPort.IntVal)
+		service.NodePort = uint32(p.NodePort)
+		service.InsideIp = s.Spec.ClusterIP
+		service.OutsideIp = s.Status.LoadBalancer.Ingress[0].IP
+	}
+	return nil
+}
+
+var (
+	new = New // a non-public new to allow overriding the New() in this package.
+)
+
+// GetTopologyServices returns the topology information.
+func GetTopologyServices(ctx context.Context, params TopologyParams) (*tpb.Topology, error) {
+	topopb, err := Load(params.TopoName)
+	if err != nil {
+		return nil, fmt.Errorf("failed to load %s: %+v", params.TopoName, err)
+	}
+
+	t, err := new(params.Kubecfg, topopb, params.TopoNewOptions...)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get topology service for %s: %+v", params.TopoName, err)
+	}
+
+	if err := t.Load(ctx); err != nil {
+		return nil, fmt.Errorf("failed to load %s: %+v", params.TopoName, err)
+	}
+
+	r, err := t.Resources(ctx)
+	if err != nil {
+		return nil, err
+	}
+	for _, n := range topopb.Nodes {
+		if len(n.Services) == 0 {
+			n.Services = map[uint32]*tpb.Service{}
+		}
+		// (TODO:hines): Remove type once deprecated
+		if n.Vendor == tpb.Vendor_KEYSIGHT || n.Type == tpb.Node_IXIA_TG {
+			// Add Keysight gnmi and grpc global services until
+			// they have a better registration mechanism for global
+			// services
+			if gnmiService, ok := r.Services["gnmi-service"]; ok {
+				serviceToProto(gnmiService, n.Services)
+			}
+			if grpcService, ok := r.Services["grpc-service"]; ok {
+				serviceToProto(grpcService, n.Services)
+			}
+		}
+		sName := fmt.Sprintf("service-%s", n.Name)
+		s, ok := r.Services[sName]
+		if !ok {
+			return nil, fmt.Errorf("service %s not found", sName)
+		}
+		serviceToProto(s, n.Services)
+	}
+
+	return topopb, nil
 }

--- a/topo/topo_test.go
+++ b/topo/topo_test.go
@@ -16,13 +16,140 @@ package topo
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"testing"
+	"time"
 
 	tfake "github.com/google/kne/api/clientset/v1beta1/fake"
+	topologyv1 "github.com/google/kne/api/types/v1beta1"
+	tpb "github.com/google/kne/proto/topo"
+	"github.com/google/kne/topo/node"
 	"github.com/h-fam/errdiff"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/proto"
+	corev1 "k8s.io/api/core/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
 	kfake "k8s.io/client-go/kubernetes/fake"
 	"k8s.io/client-go/rest"
 )
+
+var (
+	validPbTxt = `
+name: "test-data-topology"
+nodes: {
+  name: "r1"
+  type: ARISTA_CEOS
+  services: {
+	key: 1002
+	value: {
+  name: "ssh"
+	  inside: 1002
+	  outside: 22
+	  inside_ip: "1.1.1.2"
+	  outside_ip: "100.100.100.101"
+	  node_port: 22
+	}
+  }
+}
+nodes: {
+  name: "ate1"
+  type: IXIA_TG
+  services: {
+	key: 1000
+	value: {
+	  name: "gnmi"
+	  inside: 1000
+	  inside_ip: "1.1.1.1"
+	  outside_ip: "100.100.100.100"
+	  node_port: 20000
+	}
+  }
+  services: {
+	key: 1001
+	value: {
+	  name: "grpc"
+	  inside: 1001
+	  inside_ip: "1.1.1.1"
+	  outside_ip: "100.100.100.100"
+	  node_port: 20001
+	}
+  }
+  services: {
+	key: 5555
+	value: {
+	  name: "port-5555"
+	  inside: 5555
+	  outside: 5555
+	  inside_ip: "1.1.1.3"
+	  outside_ip: "100.100.100.102"
+	  node_port: 30010
+	}
+  }
+  services: {
+	key: 50071
+	value: {
+	  name: "port-50071"
+	  inside: 50071
+	  outside: 50071
+	  inside_ip: "1.1.1.3"
+	  outside_ip: "100.100.100.102"
+	  node_port: 30011
+	}
+  }
+  version: "0.0.1-9999"
+}
+links: {
+  a_node: "r1"
+  a_int: "eth9"
+  z_node: "ate1"
+  z_int: "eth1"
+}
+`
+)
+
+// defaultFakeTopology serves as a testing fake with default implementation.
+type defaultFakeTopology struct{}
+
+func (f *defaultFakeTopology) Load(context.Context) error {
+	return nil
+}
+
+func (f *defaultFakeTopology) Topology(context.Context) ([]topologyv1.Topology, error) {
+	return nil, nil
+}
+
+func (f *defaultFakeTopology) Push(context.Context) error {
+	return nil
+}
+
+func (f *defaultFakeTopology) CheckNodeStatus(context.Context, time.Duration) error {
+	return nil
+}
+
+func (f *defaultFakeTopology) Delete(context.Context) error {
+	return nil
+}
+
+func (f *defaultFakeTopology) Nodes() []node.Node {
+	return nil
+}
+
+func (f *defaultFakeTopology) Resources(context.Context) (*Resources, error) {
+	return nil, nil
+}
+
+func (f *defaultFakeTopology) Watch(context.Context) error {
+	return nil
+}
+
+func (f *defaultFakeTopology) ConfigPush(context.Context, string, io.Reader) error {
+	return nil
+}
+
+func (f *defaultFakeTopology) Node(string) (node.Node, error) {
+	return nil, nil
+}
 
 func TestCreateTopology(t *testing.T) {
 	tf, err := tfake.NewSimpleClientset()
@@ -123,6 +250,183 @@ func TestDeleteTopology(t *testing.T) {
 			err := DeleteTopology(context.Background(), tc.inputParam)
 			if diff := errdiff.Check(err, tc.wantErr); diff != "" {
 				t.Fatalf("failed: %+v", err)
+			}
+		})
+	}
+}
+
+// fakeTopology is used to test GetTopologyServices().
+type fakeTopology struct {
+	defaultFakeTopology
+	resources *Resources
+	rErr      error
+	lErr      error
+}
+
+func (f *fakeTopology) Load(context.Context) error {
+	return f.lErr
+}
+
+func (f *fakeTopology) Resources(context.Context) (*Resources, error) {
+	return f.resources, f.rErr
+}
+
+func TestGetTopologyServices(t *testing.T) {
+	tf, err := tfake.NewSimpleClientset()
+	if err != nil {
+		t.Fatalf("cannot create fake topology clientset")
+	}
+	opts := []Option{
+		WithClusterConfig(&rest.Config{}),
+		WithKubeClient(kfake.NewSimpleClientset()),
+		WithTopoClient(tf),
+	}
+	validTopoOut := &tpb.Topology{}
+	if err := prototext.Unmarshal([]byte(validPbTxt), validTopoOut); err != nil {
+		t.Fatalf("cannot Unmarshal validTopo: %v", err)
+	}
+	tests := []struct {
+		desc        string
+		inputParam  TopologyParams
+		topoNewFunc func(string, *tpb.Topology, ...Option) (TopologyManager, error)
+		want        *tpb.Topology
+		wantErr     string
+	}{{
+		desc: "load topology error",
+		inputParam: TopologyParams{
+			TopoName:       "testdata/not_there.pb.txt",
+			TopoNewOptions: opts,
+		},
+		wantErr: "no such file or directory",
+	}, {
+		desc: "empty resources",
+		inputParam: TopologyParams{
+			TopoName:       "testdata/valid_topo.pb.txt",
+			TopoNewOptions: opts,
+		},
+		topoNewFunc: func(string, *tpb.Topology, ...Option) (TopologyManager, error) {
+			return &fakeTopology{
+				resources: &Resources{},
+			}, nil
+		},
+		wantErr: "not found",
+	}, {
+		desc: "load fail",
+		inputParam: TopologyParams{
+			TopoName:       "testdata/valid_topo.pb.txt",
+			TopoNewOptions: opts,
+		},
+		topoNewFunc: func(string, *tpb.Topology, ...Option) (TopologyManager, error) {
+			return &fakeTopology{
+				lErr:      fmt.Errorf("load failed"),
+				resources: &Resources{},
+			}, nil
+		},
+		wantErr: "load failed",
+	}, {
+		desc: "valid case",
+		inputParam: TopologyParams{
+			TopoName:       "testdata/valid_topo.pb.txt",
+			TopoNewOptions: opts,
+		},
+		topoNewFunc: func(string, *tpb.Topology, ...Option) (TopologyManager, error) {
+			return &fakeTopology{
+				resources: &Resources{
+					Services: map[string]*corev1.Service{
+						"gnmi-service": {
+							Spec: corev1.ServiceSpec{
+								ClusterIP: "1.1.1.1",
+								Ports: []corev1.ServicePort{{
+									Port:     1000,
+									NodePort: 20000,
+									Name:     "gnmi",
+								}},
+							},
+							Status: corev1.ServiceStatus{
+								LoadBalancer: corev1.LoadBalancerStatus{
+									Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.100"}},
+								},
+							},
+						},
+						"grpc-service": {
+							Spec: corev1.ServiceSpec{
+								ClusterIP: "1.1.1.1",
+								Ports: []corev1.ServicePort{{
+									Port:     1001,
+									NodePort: 20001,
+									Name:     "grpc",
+								}},
+							},
+							Status: corev1.ServiceStatus{
+								LoadBalancer: corev1.LoadBalancerStatus{
+									Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.100"}},
+								},
+							},
+						},
+						"service-r1": {
+							Spec: corev1.ServiceSpec{
+								ClusterIP: "1.1.1.2",
+								Ports: []corev1.ServicePort{{
+									Port:       1002,
+									NodePort:   22,
+									Name:       "ssh",
+									TargetPort: intstr.IntOrString{IntVal: 22},
+								}},
+							},
+							Status: corev1.ServiceStatus{
+								LoadBalancer: corev1.LoadBalancerStatus{
+									Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.101"}},
+								},
+							},
+						},
+						"service-ate1": {
+							Spec: corev1.ServiceSpec{
+								ClusterIP: "1.1.1.3",
+								Ports: []corev1.ServicePort{{
+									Port:       5555,
+									NodePort:   30010,
+									Name:       "port-5555",
+									TargetPort: intstr.IntOrString{IntVal: 5555},
+								}, {
+									Port:       50071,
+									NodePort:   30011,
+									Name:       "port-50071",
+									TargetPort: intstr.IntOrString{IntVal: 50071},
+								}},
+							},
+							Status: corev1.ServiceStatus{
+								LoadBalancer: corev1.LoadBalancerStatus{
+									Ingress: []corev1.LoadBalancerIngress{{IP: "100.100.100.102"}},
+								},
+							},
+						},
+					},
+				},
+			}, nil
+		},
+		wantErr: "",
+		want:    validTopoOut,
+	},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.desc, func(t *testing.T) {
+			if tc.topoNewFunc != nil {
+				origNew := new
+				new = tc.topoNewFunc
+				defer func() {
+					new = origNew
+				}()
+			}
+			got, err := GetTopologyServices(context.Background(), tc.inputParam)
+			if diff := errdiff.Check(err, tc.wantErr); diff != "" {
+				t.Fatalf("failed: %+v", err)
+			}
+			if tc.wantErr != "" {
+				return
+			}
+			if !proto.Equal(got, tc.want) {
+				t.Fatalf("get topology service failed: got:\n%s\n, want:\n%s\n", got, tc.want)
 			}
 		})
 	}


### PR DESCRIPTION
This PR extracts the logics of kne_cli's "show topology service" into GetTopologyServices() in topo.go.

Test
==
* Unit tests are added for both topo/topo_test.go and cmd/topology/topology_test.go.
* Compiled and ran the refactored kne_cli in the GCE VM, compared its output with the same parameters with current kne_cli, and the output were consistent.