### PR TITLE
Add TopologyManager DeleteCluster method

### DIFF
--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -163,7 +163,8 @@ func (s *server) DeleteCluster(ctx context.Context, req *cpb.DeleteClusterReques
 		}
 	}
 	if !found {
-		return nil, status.Errorf(codes.NotFound, "cluster does not exist, or is not a kind cluster")
+		log.Infof("Cluster %q does not exist, or is not a kind cluster (%v)", req.GetName(), clusters)
+		return nil, status.Errorf(codes.NotFound, "cluster %q does not exist, or is not a kind cluster (%v)", req.GetName(), clusters)
 	}
 	args := []string{"delete", "cluster"}
 	if req.GetName() != "" {

--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -151,7 +151,7 @@ func (s *server) DeleteCluster(ctx context.Context, req *cpb.DeleteClusterReques
 	var b bytes.Buffer
 	execer.SetStdout(&b)
 	if err := execer.Exec("kind", "get", "clusters"); err != nil {
-		return nil, status.Errorf(codes.NotFound, "cannot check for existence of kind cluster")
+		return nil, status.Errorf(codes.NotFound, "cannot check for existence of kind cluster: %v", err)
 	}
 	execer.SetStdout(logOut)
 	clusters := strings.Split(b.String(), "\n")
@@ -171,7 +171,7 @@ func (s *server) DeleteCluster(ctx context.Context, req *cpb.DeleteClusterReques
 		args = append(args, "--name", req.GetName())
 	}
 	if err := execer.Exec("kind", args...); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to delete cluster using cli")
+		return nil, status.Errorf(codes.Internal, "failed to delete cluster using cli: %v", err)
 	}
 	log.Infof("Deleted kind cluster %q", req.GetName())
 	return &cpb.DeleteClusterResponse{}, nil

--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -57,7 +57,7 @@ func init() {
 type logger struct{}
 
 func (l *logger) Write(p []byte) (int, error) {
-	log.Info(p)
+	log.Info(string(p))
 	return len(p), nil
 }
 
@@ -127,7 +127,7 @@ func (s *server) CreateCluster(ctx context.Context, req *cpb.CreateClusterReques
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unable to parse request: %v", err)
 	}
-	log.Infof("Parsed request into deployment: %+v", d)
+	log.Infof("Parsed request into deployment: %v", d)
 	if err := d.Deploy(ctx, defaultKubeCfg); err != nil {
 		resp := &cpb.CreateClusterResponse{
 			Name:  req.GetKind().Name,

--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -14,25 +14,25 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"flag"
 	"fmt"
 	"net"
 	"os"
-	"path/filepath"
 	"os/exec"
-	"bytes"
+	"path/filepath"
 	"strings"
 
 	log "github.com/golang/glog"
 	"github.com/google/kne/deploy"
+	kexec "github.com/google/kne/os/exec"
 	cpb "github.com/google/kne/proto/controller"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
-	"google.golang.org/grpc/status"
 	"google.golang.org/grpc/credentials/alts"
+	"google.golang.org/grpc/status"
 	"k8s.io/client-go/util/homedir"
-	kexec "github.com/google/kne/os/exec"
 )
 
 var (
@@ -54,7 +54,7 @@ func init() {
 	}
 }
 
-type logger struct {}
+type logger struct{}
 
 func (l *logger) Write(p []byte) (int, error) {
 	log.Info(p)
@@ -146,8 +146,8 @@ func (s *server) CreateCluster(ctx context.Context, req *cpb.CreateClusterReques
 func (s *server) DeleteCluster(ctx context.Context, req *cpb.DeleteClusterRequest) (*cpb.DeleteClusterResponse, error) {
 	log.Infof("Received DeleteCluster request: %+v", req)
 	if _, err := exec.LookPath("kind"); err != nil {
-                return nil, status.Errorf(codes.Internal, "kind cli not installed on host")
-        }
+		return nil, status.Errorf(codes.Internal, "kind cli not installed on host")
+	}
 	var b bytes.Buffer
 	execer.SetStdout(&b)
 	if err := execer.Exec("kind", "get", "clusters"); err != nil {
@@ -165,14 +165,14 @@ func (s *server) DeleteCluster(ctx context.Context, req *cpb.DeleteClusterReques
 	if !found {
 		return nil, status.Errorf(codes.NotFound, "cluster %q does not exist, or is not a kind cluster")
 	}
-        args := []string{"delete", "cluster"}
-        if req.GetName() != "" {
-                args = append(args, "--name", req.GetName())
-        }
-        if err := execer.Exec("kind", args...); err != nil {
-                return nil, status.Errorf(codes.Internal, "failed to delete cluster using cli")
-        }
-        log.Infof("Deleted kind cluster %q", req.GetName())
+	args := []string{"delete", "cluster"}
+	if req.GetName() != "" {
+		args = append(args, "--name", req.GetName())
+	}
+	if err := execer.Exec("kind", args...); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to delete cluster using cli")
+	}
+	log.Infof("Deleted kind cluster %q", req.GetName())
 	return &cpb.DeleteClusterResponse{}, nil
 }
 

--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -163,7 +163,7 @@ func (s *server) DeleteCluster(ctx context.Context, req *cpb.DeleteClusterReques
 		}
 	}
 	if !found {
-		return nil, status.Errorf(codes.NotFound, "cluster %q does not exist, or is not a kind cluster")
+		return nil, status.Errorf(codes.NotFound, "cluster does not exist, or is not a kind cluster")
 	}
 	args := []string{"delete", "cluster"}
 	if req.GetName() != "" {

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -93,10 +93,7 @@ type Deployment struct {
 }
 
 func (d *Deployment) String() string {
-	b, err := json.MarshalIndent(d, "", "\t")
-	if err != nil {
-		return fmt.Sprintf("%+v", d)
-	}
+	b, _ := json.MarshalIndent(d, "", "\t")
 	return string(b)
 }
 

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -5,6 +5,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net"

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -91,6 +91,14 @@ type Deployment struct {
 	CNI     CNI
 }
 
+func (d *Deployment) String() string {
+	b, err := json.MarshalIndent(d, "", "\t")
+	if err != nil {
+		return fmt.Sprintf("%+v", d)
+	}
+	return string(b)
+}
+
 func (d *Deployment) Deploy(ctx context.Context, kubecfg string) error {
 	log.Infof("Deploying cluster...")
 	if err := d.Cluster.Deploy(ctx); err != nil {


### PR DESCRIPTION
- method only supports kind clusters as of now
- method returns appropriate grpc status codes to indicate if the cluster name does not exist or is not a kind cluster
- fix logging

Tested: end-to-end with instance manager