### PR TITLE
Add ShowCluster method implementation to TopologyManager

### DIFF
--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -51,7 +51,7 @@ func init() {
 type server struct {
 	cpb.UnimplementedTopologyManagerServer
 
-	mu sync.Mutex
+	mu          sync.Mutex
 	deployments map[string]*deploy.Deployment
 }
 
@@ -116,7 +116,7 @@ func newDeployment(req *cpb.CreateClusterRequest) (*deploy.Deployment, error) {
 }
 
 func (s *server) CreateCluster(ctx context.Context, req *cpb.CreateClusterRequest) (*cpb.CreateClusterResponse, error) {
-	log.Infof("Received CreateCluster request: %+v", req)
+	log.Infof("Received CreateCluster request: %v", req)
 	d, err := newDeployment(req)
 	if err != nil {
 		return nil, status.Errorf(codes.InvalidArgument, "unable to parse request: %v", err)
@@ -141,7 +141,7 @@ func (s *server) CreateCluster(ctx context.Context, req *cpb.CreateClusterReques
 }
 
 func (s *server) DeleteCluster(ctx context.Context, req *cpb.DeleteClusterRequest) (*cpb.DeleteClusterResponse, error) {
-	log.Infof("Received DeleteCluster request: %+v", req)
+	log.Infof("Received DeleteCluster request: %v", req)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	d, ok := s.deployments[req.GetName()]
@@ -157,7 +157,7 @@ func (s *server) DeleteCluster(ctx context.Context, req *cpb.DeleteClusterReques
 }
 
 func (s *server) ShowCluster(ctx context.Context, req *cpb.ShowClusterRequest) (*cpb.ShowClusterResponse, error) {
-	log.Infof("Received ShowCluster request: %+v", req)
+	log.Infof("Received ShowCluster request: %v", req)
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	d, ok := s.deployments[req.GetName()]

--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -14,19 +14,16 @@
 package main
 
 import (
-	"bytes"
 	"context"
 	"flag"
 	"fmt"
 	"net"
 	"os"
-	"os/exec"
 	"path/filepath"
-	"strings"
+	"sync"
 
 	log "github.com/golang/glog"
 	"github.com/google/kne/deploy"
-	kexec "github.com/google/kne/os/exec"
 	cpb "github.com/google/kne/proto/controller"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
@@ -36,9 +33,6 @@ import (
 )
 
 var (
-	logOut = &logger{}
-	execer = kexec.NewExecer(logOut, logOut)
-
 	defaultKubeCfg            = ""
 	defaultMetallbManifestDir = ""
 	defaultMeshnetManifestDir = ""
@@ -54,15 +48,11 @@ func init() {
 	}
 }
 
-type logger struct{}
-
-func (l *logger) Write(p []byte) (int, error) {
-	log.Info(string(p))
-	return len(p), nil
-}
-
 type server struct {
 	cpb.UnimplementedTopologyManagerServer
+
+	mu sync.Mutex
+	deployments map[string]*deploy.Deployment
 }
 
 func newDeployment(req *cpb.CreateClusterRequest) (*deploy.Deployment, error) {
@@ -130,14 +120,17 @@ func (s *server) CreateCluster(ctx context.Context, req *cpb.CreateClusterReques
 	log.Infof("Parsed request into deployment: %v", d)
 	if err := d.Deploy(ctx, defaultKubeCfg); err != nil {
 		resp := &cpb.CreateClusterResponse{
-			Name:  req.GetKind().Name,
+			Name:  d.Cluster.GetName(),
 			State: cpb.ClusterState_CLUSTER_STATE_ERROR,
 		}
 		return resp, status.Errorf(codes.Internal, "failed to deploy cluster: %v", err)
 	}
-	log.Infof("Cluster %q deployed and ready for topology", req.GetKind().Name)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.deployments[d.Cluster.GetName()] = d
+	log.Infof("Cluster %q deployed and ready for topology", d.Cluster.GetName())
 	resp := &cpb.CreateClusterResponse{
-		Name:  req.GetKind().Name,
+		Name:  d.Cluster.GetName(),
 		State: cpb.ClusterState_CLUSTER_STATE_RUNNING,
 	}
 	return resp, nil
@@ -145,36 +138,32 @@ func (s *server) CreateCluster(ctx context.Context, req *cpb.CreateClusterReques
 
 func (s *server) DeleteCluster(ctx context.Context, req *cpb.DeleteClusterRequest) (*cpb.DeleteClusterResponse, error) {
 	log.Infof("Received DeleteCluster request: %+v", req)
-	if _, err := exec.LookPath("kind"); err != nil {
-		return nil, status.Errorf(codes.Internal, "kind cli not installed on host")
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	d, ok := s.deployments[req.GetName()]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "cluster %q not found, can only delete clusters created using TopologyManager")
 	}
-	var b bytes.Buffer
-	execer.SetStdout(&b)
-	if err := execer.Exec("kind", "get", "clusters"); err != nil {
-		return nil, status.Errorf(codes.NotFound, "cannot check for existence of kind cluster: %v", err)
+	if err := d.Delete(); err != nil {
+		return nil, status.Errorf(codes.Internal, "failed to delete cluster: %v", err)
 	}
-	execer.SetStdout(logOut)
-	clusters := strings.Split(b.String(), "\n")
-	found := false
-	for _, c := range clusters {
-		if c == req.GetName() {
-			found = true
-			break
-		}
-	}
-	if !found {
-		log.Infof("Cluster %q does not exist, or is not a kind cluster (%v)", req.GetName(), clusters)
-		return nil, status.Errorf(codes.NotFound, "cluster %q does not exist, or is not a kind cluster (%v)", req.GetName(), clusters)
-	}
-	args := []string{"delete", "cluster"}
-	if req.GetName() != "" {
-		args = append(args, "--name", req.GetName())
-	}
-	if err := execer.Exec("kind", args...); err != nil {
-		return nil, status.Errorf(codes.Internal, "failed to delete cluster using cli: %v", err)
-	}
-	log.Infof("Deleted kind cluster %q", req.GetName())
+	delete(s.deployments, req.GetName())
+	log.Infof("Deleted cluster %q", d.Cluster.GetName())
 	return &cpb.DeleteClusterResponse{}, nil
+}
+
+func (s *server) ShowCluster(ctx context.Context, req *cpb.ShowClusterRequest) (*cpb.ShowClusterResponse, error) {
+	log.Infof("Received ShowCluster request: %+v", req)
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	d, ok := s.deployments[req.GetName()]
+	if !ok {
+		return nil, status.Errorf(codes.NotFound, "cluster %q not found, can only show clusters created using TopologyManager")
+	}
+	if err := d.Healthy(ctx); err != nil {
+		return &cpb.ShowClusterResponse{State: cpb.ClusterState_CLUSTER_STATE_ERROR}, nil
+	}
+	return &cpb.ShowClusterResponse{State: cpb.ClusterState_CLUSTER_STATE_RUNNING}, nil
 }
 
 func validatePath(path string) (string, error) {

--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -55,6 +55,10 @@ type server struct {
 	deployments map[string]*deploy.Deployment
 }
 
+func newServer() *server {
+	return &server{deployments: map[string]*deploy.Deployment{}}
+}
+
 func newDeployment(req *cpb.CreateClusterRequest) (*deploy.Deployment, error) {
 	d := &deploy.Deployment{}
 	switch kind := req.ClusterSpec.(type) {
@@ -186,7 +190,7 @@ func main() {
 	}
 	creds := alts.NewServerCreds(alts.DefaultServerOptions())
 	s := grpc.NewServer(grpc.Creds(creds))
-	cpb.RegisterTopologyManagerServer(s, &server{})
+	cpb.RegisterTopologyManagerServer(s, newServer())
 	log.Infof("Controller server listening at %v", lis.Addr())
 	if err := s.Serve(lis); err != nil {
 		log.Fatalf("failed to serve: %v", err)


### PR DESCRIPTION
- generalize DeleteCluster to work with non-kind clusters
- ShowCluster status check works for all cluster, cni, and ingress implementations
- topology_names repeated field is currently not used, unclear how to provide this list. will add in a later PR if needed
- Delete/ShowCluster only works for clusters created using CreateCluster. This is due to the extra deployment info stored during cluster creation such as ingress/cni/cluster type in order to perform relevant health checks and deletion