### PR TITLE
Fix kubecfg validation

### DIFF
--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -203,11 +203,11 @@ func (s *server) CreateTopology(ctx context.Context, req *cpb.CreateTopologyRequ
 		if !filepath.IsAbs(path) {
 			path = filepath.Join(defaultTopoBasePath, path)
 		}
-		node.GetConfig().ConfigData = &tpb.Config_File{File: path}
-		log.Infof("Checking config path: %q", node.GetConfig().GetFile())
-		if _, err := validatePath(node.GetConfig().GetFile()); err != nil {
+		log.Infof("Checking config path: %q", path)
+		if _, err := validatePath(path); err != nil {
 			return nil, status.Errorf(codes.InvalidArgument, "config file not found for node %q: %v", node.GetName(), err)
 		}
+		node.GetConfig().ConfigData = &tpb.Config_File{File: path}
 	}
 	// Saves the original topology protobuf.
 	txtPb, err := prototext.Marshal(topoPb)

--- a/controller/server/main.go
+++ b/controller/server/main.go
@@ -220,7 +220,7 @@ func (s *server) CreateTopology(ctx context.Context, req *cpb.CreateTopologyRequ
 	}
 	kcfg, err := validatePath(path)
 	if err != nil {
-		return nil, status.Errorf(codes.InvalidArgument, "kubecfg at %q does not exist: %v", err)
+		return nil, status.Errorf(codes.InvalidArgument, "kubecfg %q does not exist: %v", path, err)
 	}
 	if err := topo.CreateTopology(ctx, topo.TopologyParams{
 		TopoNewOptions: []topo.Option{topo.WithTopology(topoPb)},
@@ -250,7 +250,7 @@ func (s *server) DeleteTopology(ctx context.Context, req *cpb.DeleteTopologyRequ
 	}
 	kcfg, err := validatePath(defaultKubeCfg)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "default kubecfg at %q does not exist: %v", err)
+		return nil, status.Errorf(codes.Internal, "default kubecfg %q does not exist: %v", defaultKubeCfg, err)
 	}
 	if err := topo.DeleteTopology(ctx, topo.TopologyParams{
 		TopoNewOptions: []topo.Option{topo.WithTopology(topoPb)},
@@ -275,7 +275,7 @@ func (s *server) ShowTopology(ctx context.Context, req *cpb.ShowTopologyRequest)
 	}
 	kcfg, err := validatePath(defaultKubeCfg)
 	if err != nil {
-		return nil, status.Errorf(codes.Internal, "default kubecfg at %q does not exist: %v", err)
+		return nil, status.Errorf(codes.Internal, "default kubecfg %q does not exist: %v", defaultKubeCfg, err)
 	}
 	resp, err := topo.GetTopologyServices(ctx, topo.TopologyParams{
 		TopoNewOptions: []topo.Option{topo.WithTopology(topoPb)},


### PR DESCRIPTION
- also use `defaultTopoBasePath` if the config path provided isn't absolute