### PR TITLE
Add IxiaTG controller deployment

### DIFF
--- a/cmd/deploy/deploy_test.go
+++ b/cmd/deploy/deploy_test.go
@@ -76,6 +76,63 @@ cni:
   kind: InvalidCNI
   spec:
     manifests: ../../manifests/meshnet/base`
+	invalidControllers = `
+cluster:
+  kind: Kind
+  spec:
+    name: kne
+    recycle: True
+    version: 0.11.1
+    image: kindest/node:v1.22.0
+ingress:
+  kind: MetalLB
+  spec:
+    manifests: ../../manifests/metallb
+    ip_count: 100
+cni:
+  kind: Meshnet
+  spec:
+    manifests: ../../manifests/meshnet/base
+controllers:
+  - kind: IxiaTG
+    spec:
+      manifests: path/to/manifest
+      configMap:
+        release: some-value
+        images:
+          - name: controller
+          - path: some/path
+          - tag: latest
+  - kind: InvalidController
+    spec:
+      manifests: path/to/manifest`
+	validControllers = `
+cluster:
+  kind: Kind
+  spec:
+    name: kne
+    recycle: True
+    version: 0.11.1
+    image: kindest/node:v1.22.0
+ingress:
+  kind: MetalLB
+  spec:
+    manifests: ../../manifests/metallb
+    ip_count: 100
+cni:
+  kind: Meshnet
+  spec:
+    manifests: ../../manifests/meshnet/base
+controllers:
+  - kind: IxiaTG
+    spec:
+      manifests: path/to/manifest
+      configMap:
+        release: some-value
+        images:
+          - name: controller
+            path: some/path
+            tag: latest`
 )
 
 func TestNew(t *testing.T) {
@@ -103,6 +160,13 @@ func TestNewDeployment(t *testing.T) {
 		desc:    "invalid cni",
 		cfg:     invalidCNI,
 		wantErr: "CNI type not supported",
+	}, {
+		desc:    "invalid controllers",
+		cfg:     invalidControllers,
+		wantErr: "controller type not supported",
+	}, {
+		desc: "valid controllers",
+		cfg:  validControllers,
 	}, {
 		desc: "kind example",
 		cfg:  "",

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -40,6 +40,14 @@ const (
 {{end}}  }
 }
 `
+	ixiaTGConfigMapHeader = `apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: ixiatg-release-config
+  namespace: ixiatg-op-system
+data:
+  versions: |
+    `
 )
 
 var (
@@ -89,10 +97,17 @@ type CNI interface {
 	Healthy(context.Context) error
 }
 
+type Controller interface {
+	Deploy(context.Context) error
+	SetKClient(kubernetes.Interface)
+	Healthy(context.Context) error
+}
+
 type Deployment struct {
-	Cluster Cluster
-	Ingress Ingress
-	CNI     CNI
+	Cluster     Cluster
+	Ingress     Ingress
+	CNI         CNI
+	Controllers []Controller
 }
 
 func (d *Deployment) String() string {
@@ -137,6 +152,19 @@ func (d *Deployment) Deploy(ctx context.Context, kubecfg string) error {
 		return err
 	}
 	log.Infof("CNI healthy")
+	for _, c := range d.Controllers {
+		log.Infof("Deploying controller...")
+		if err := c.Deploy(ctx); err != nil {
+			return err
+		}
+		c.SetKClient(kClient)
+		tCtx, cancel = context.WithTimeout(ctx, 1*time.Minute)
+		defer cancel()
+		if err := c.Healthy(tCtx); err != nil {
+			return err
+		}
+	}
+	log.Infof("Controllers deployed and healthy")
 	return nil
 }
 
@@ -166,6 +194,14 @@ func (d *Deployment) Healthy(ctx context.Context) error {
 		return err
 	}
 	log.Infof("CNI healthy")
+	for _, c := range d.Controllers {
+		tCtx, cancel = context.WithTimeout(ctx, 1*time.Minute)
+		defer cancel()
+		if err := c.Healthy(tCtx); err != nil {
+			return err
+		}
+	}
+	log.Infof("Controllers healthy")
 	return nil
 }
 
@@ -517,34 +553,7 @@ func (m *MetalLBSpec) Deploy(ctx context.Context) error {
 }
 
 func (m *MetalLBSpec) Healthy(ctx context.Context) error {
-	log.Infof("Waiting on Metallb to be Healthy")
-	w, err := m.kClient.AppsV1().Deployments("metallb-system").Watch(ctx, metav1.ListOptions{})
-	if err != nil {
-		return err
-	}
-	ch := w.ResultChan()
-	for {
-		select {
-		case <-ctx.Done():
-			return fmt.Errorf("context canceled before healthy")
-		case e, ok := <-ch:
-			if !ok {
-				return fmt.Errorf("watch channel closed before healthy")
-			}
-			d, ok := e.Object.(*appsv1.Deployment)
-			if !ok {
-				return fmt.Errorf("invalid object type: %T", d)
-			}
-			if d.Status.AvailableReplicas == 1 &&
-				d.Status.ReadyReplicas == 1 &&
-				d.Status.UnavailableReplicas == 0 &&
-				d.Status.Replicas == 1 &&
-				d.Status.UpdatedReplicas == 1 {
-				log.Infof("Metallb Healthy")
-				return nil
-			}
-		}
-	}
+	return deploymentHealthy(ctx, m.kClient, "metallb-system")
 }
 
 type MeshnetSpec struct {
@@ -589,6 +598,99 @@ func (m *MeshnetSpec) Healthy(ctx context.Context) error {
 			if d.Status.NumberReady == d.Status.DesiredNumberScheduled &&
 				d.Status.NumberUnavailable == 0 {
 				log.Infof("Meshnet Healthy")
+				return nil
+			}
+		}
+	}
+}
+
+type IxiaTGSpec struct {
+	ManifestDir string           `yaml:"manifests"`
+	ConfigMap   *IxiaTGConfigMap `yaml:"configMap"`
+	kClient     kubernetes.Interface
+}
+
+type IxiaTGConfigMap struct {
+	Release string         `yaml:"release" json:"release"`
+	Images  []*IxiaTGImage `yaml:"images" json:"images"`
+}
+
+type IxiaTGImage struct {
+	Name string `yaml:"name" json:"name"`
+	Path string `yaml:"path" json:"path"`
+	Tag  string `yaml:"tag" json:"tag"`
+}
+
+func (i *IxiaTGSpec) SetKClient(c kubernetes.Interface) {
+	i.kClient = c
+}
+
+func (i *IxiaTGSpec) Deploy(ctx context.Context) error {
+	log.Infof("Deploying IxiaTG controller from: %s", i.ManifestDir)
+	if err := execer.Exec("kubectl", "apply", "-f", filepath.Join(i.ManifestDir, "ixiatg-operator.yaml")); err != nil {
+		return err
+	}
+	if i.ConfigMap == nil {
+		path := filepath.Join(i.ManifestDir, "ixia-configmap.yaml")
+		if _, err := os.Stat(path); err == nil {
+			log.Infof("Deploying IxiaTG configmap from: %s", path)
+			if err := execer.Exec("kubectl", "apply", "-f", path); err != nil {
+				return err
+			}
+		}
+		log.Infof("IxiaTG controller Deployed")
+		return nil
+	}
+	b, err := json.MarshalIndent(i.ConfigMap, "    ", "  ")
+	if err != nil {
+		return err
+	}
+	b = append([]byte(ixiaTGConfigMapHeader), b...)
+	f, err := os.CreateTemp("", "ixiatg-configmap-*.yaml")
+	if err != nil {
+		return err
+	}
+	defer os.Remove(f.Name())
+	if _, err := f.Write(b); err != nil {
+		return err
+	}
+	log.Infof("Deploying IxiaTG configmap from: %s", f.Name())
+	if err := execer.Exec("kubectl", "apply", "-f", f.Name()); err != nil {
+		return err
+	}
+	log.Infof("IxiaTG controller Deployed")
+	return nil
+}
+
+func (i *IxiaTGSpec) Healthy(ctx context.Context) error {
+	return deploymentHealthy(ctx, i.kClient, "ixiatg-op-system")
+}
+
+func deploymentHealthy(ctx context.Context, c kubernetes.Interface, name string) error {
+	log.Infof("Waiting on deployment %q to be healthy", name)
+	w, err := c.AppsV1().Deployments(name).Watch(ctx, metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+	ch := w.ResultChan()
+	for {
+		select {
+		case <-ctx.Done():
+			return fmt.Errorf("context canceled before healthy")
+		case e, ok := <-ch:
+			if !ok {
+				return fmt.Errorf("watch channel closed before healthy")
+			}
+			d, ok := e.Object.(*appsv1.Deployment)
+			if !ok {
+				return fmt.Errorf("invalid object type: %T", d)
+			}
+			if d.Status.AvailableReplicas == 1 &&
+				d.Status.ReadyReplicas == 1 &&
+				d.Status.UnavailableReplicas == 0 &&
+				d.Status.Replicas == 1 &&
+				d.Status.UpdatedReplicas == 1 {
+				log.Infof("Deployment %q healthy", name)
 				return nil
 			}
 		}

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -53,7 +53,7 @@ data:
 var (
 	dockerConfigTemplate = template.Must(template.New("dockerConfig").Parse(dockerConfigTemplateContents))
 	logOut               = log.StandardLogger().Out
-	healthTimeout = time.Minute
+	healthTimeout        = time.Minute
 
 	// execer handles all execs on host.
 	execer execerInterface = kexec.NewExecer(logOut, logOut)
@@ -61,7 +61,7 @@ var (
 	// Stubs for testing.
 	newProvider  = defaultProvider
 	execLookPath = exec.LookPath
-	osStat = os.Stat
+	osStat       = os.Stat
 )
 
 //go:generate mockgen -source=specs.go -destination=mocks/mock_provider.go -package=mocks provider

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -695,11 +695,11 @@ func TestIxiaTGSpec(t *testing.T) {
 			k.PrependWatchReactor("deployments", reaction)
 		},
 	}, {
-		desc:   "no configmap",
-		i:      &IxiaTGSpec{},
-		execer: exec.NewFakeExecer(nil),
+		desc:       "no configmap",
+		i:          &IxiaTGSpec{},
+		execer:     exec.NewFakeExecer(nil),
 		cmNotFound: true,
-		dErr:   "ixia configmap not found",
+		dErr:       "ixia configmap not found",
 	}, {
 		desc:   "operator deploy error",
 		i:      &IxiaTGSpec{},


### PR DESCRIPTION
- Adds ability to deploy the IxiaTG controller during `kne_cli deploy` cmd


Add the controllers field to the deployment yaml, optionally specify a custom configmap

e.g.

```
controllers:
  - kind: IxiaTG
    spec:
      manifests: ../../../keysight/athena/operator
```

```
controllers:
  - kind: IxiaTG
    spec:
      manifests: ../../../keysight/athena/operator
      configMap:
        release: 0.0.1-9999
        images:
          - name: controller
            path: some/path
            tag: latest
          - name: ...
          ...`
```