### PR TITLE
Standardize dependency checking for kne deploy

### DIFF
--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -227,8 +227,9 @@ func (k *KindSpec) Deploy(ctx context.Context) error {
 		return errors.Wrap(err, `install "kind" to deploy`)
 	}
 	if k.Recycle {
+		log.Infof("Attempting to recycle existing cluster %q...", k.Name)
 		if err := execer.Exec("kubectl", "cluster-info", "--context", fmt.Sprintf("kind-%s", k.Name)); err == nil {
-			log.Infof("Recycling existing cluster: %s", k.Name)
+			log.Infof("Recycling existing cluster %q", k.Name)
 			return nil
 		}
 	}

--- a/deploy/deploy.go
+++ b/deploy/deploy.go
@@ -19,6 +19,7 @@ import (
 	dtypes "github.com/docker/docker/api/types"
 	dclient "github.com/docker/docker/client"
 	kexec "github.com/google/kne/os/exec"
+	"github.com/openconfig/gnmi/errlist"
 	"github.com/pkg/errors"
 	log "github.com/sirupsen/logrus"
 	"gopkg.in/yaml.v3"
@@ -28,7 +29,6 @@ import (
 	"k8s.io/apimachinery/pkg/fields"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/tools/clientcmd"
-	"sigs.k8s.io/kind/pkg/cluster"
 )
 
 const (
@@ -59,20 +59,9 @@ var (
 	execer execerInterface = kexec.NewExecer(logOut, logOut)
 
 	// Stubs for testing.
-	newProvider  = defaultProvider
 	execLookPath = exec.LookPath
 	osStat       = os.Stat
 )
-
-//go:generate mockgen -source=specs.go -destination=mocks/mock_provider.go -package=mocks provider
-type provider interface {
-	List() ([]string, error)
-	Create(name string, options ...cluster.CreateOption) error
-}
-
-func defaultProvider() provider {
-	return cluster.NewProvider(cluster.ProviderWithLogger(&logAdapter{log.StandardLogger()}))
-}
 
 type execerInterface interface {
 	Exec(string, ...string) error
@@ -117,13 +106,27 @@ func (d *Deployment) String() string {
 	return string(b)
 }
 
+func checkDependencies() error {
+	bins := []string{"docker", "kubectl"}
+	var errs errlist.List
+	for _, bin := range bins {
+		if _, err := execLookPath(bin); err != nil {
+			errs.Add(fmt.Errorf("install dependency %q to deploy", bin))
+		}
+	}
+	return errs.Err()
+}
+
 func (d *Deployment) Deploy(ctx context.Context, kubecfg string) error {
+	if err := checkDependencies(); err != nil {
+		return err
+	}
 	log.Infof("Deploying cluster...")
 	if err := d.Cluster.Deploy(ctx); err != nil {
 		return err
 	}
 	log.Infof("Cluster deployed")
-	// Once cluster is up set kClient
+	// Once cluster is up, set kClient
 	rCfg, err := clientcmd.BuildConfigFromFlags("", kubecfg)
 	if err != nil {
 		return err
@@ -215,48 +218,19 @@ type KindSpec struct {
 	Retain                   bool              `yaml:"retain"`
 	Wait                     time.Duration     `yaml:"wait"`
 	Kubecfg                  string            `yaml:"kubecfg"`
-	DeployWithClient         bool              `yaml:"deployWithClient"`
 	GoogleArtifactRegistries []string          `yaml:"googleArtifactRegistries"`
 	ContainerImages          map[string]string `yaml:"containerImages"`
 }
 
 func (k *KindSpec) Deploy(ctx context.Context) error {
-	provider := newProvider()
-	if k.Recycle {
-		clusters, err := provider.List()
-		if err != nil {
-			return err
-		}
-		for _, v := range clusters {
-			if k.Name == v {
-				log.Infof("Recycling existing cluster: %s", v)
-				return nil
-			}
-		}
-	}
-	if k.DeployWithClient {
-		if len(k.GoogleArtifactRegistries) != 0 {
-			return fmt.Errorf("setting up access to artifact registries %v requires unsetting the deployWithClient field", k.GoogleArtifactRegistries)
-		}
-		if len(k.ContainerImages) != 0 {
-			return fmt.Errorf("loading container images requires unsetting the deployWithClient field")
-		}
-		if err := provider.Create(
-			k.Name,
-			cluster.CreateWithNodeImage(k.Image),
-			cluster.CreateWithRetain(k.Retain),
-			cluster.CreateWithWaitForReady(k.Wait),
-			cluster.CreateWithKubeconfigPath(k.Kubecfg),
-			cluster.CreateWithDisplayUsage(true),
-			cluster.CreateWithDisplaySalutation(true),
-		); err != nil {
-			return errors.Wrap(err, "failed to create cluster using kind client")
-		}
-		log.Infof("Deployed kind cluster using kind client: %s", k.Name)
-		return nil
-	}
 	if _, err := execLookPath("kind"); err != nil {
-		return errors.Wrap(err, "install kind cli to deploy, or set the deployWithClient field")
+		return errors.Wrap(err, `install "kind" to deploy`)
+	}
+	if k.Recycle {
+		if err := execer.Exec("kubectl", "cluster-info", "--context", fmt.Sprintf("kind-%s", k.Name)); err == nil {
+			log.Infof("Recycling existing cluster: %s", k.Name)
+			return nil
+		}
 	}
 	args := []string{"create", "cluster"}
 	if k.Name != "" {
@@ -275,7 +249,7 @@ func (k *KindSpec) Deploy(ctx context.Context) error {
 		args = append(args, "--kubeconfig", k.Kubecfg)
 	}
 	if err := execer.Exec("kind", args...); err != nil {
-		return errors.Wrap(err, "failed to create cluster using cli")
+		return errors.Wrap(err, "failed to create cluster")
 	}
 	log.Infof("Deployed kind cluster: %s", k.Name)
 	if len(k.GoogleArtifactRegistries) != 0 {
@@ -294,9 +268,6 @@ func (k *KindSpec) Deploy(ctx context.Context) error {
 }
 
 func (k *KindSpec) Delete() error {
-	if _, err := execLookPath("kind"); err != nil {
-		return errors.Wrap(err, "install kind cli to delete")
-	}
 	args := []string{"delete", "cluster"}
 	if k.Name != "" {
 		args = append(args, "--name", k.Name)
@@ -308,9 +279,6 @@ func (k *KindSpec) Delete() error {
 }
 
 func (k *KindSpec) Healthy() error {
-	if _, err := exec.LookPath("kubectl"); err != nil {
-		return errors.Wrap(err, "install kubectl to check health")
-	}
 	if err := execer.Exec("kubectl", "cluster-info", "--context", fmt.Sprintf("kind-%s", k.GetName())); err != nil {
 		return errors.Wrap(err, "cluster not healthy")
 	}
@@ -326,10 +294,7 @@ func (k *KindSpec) GetName() string {
 
 func (k *KindSpec) setupGoogleArtifactRegistryAccess() error {
 	if _, err := execLookPath("gcloud"); err != nil {
-		return errors.Wrap(err, "install gcloud cli to setup Google Artifact Registry access")
-	}
-	if _, err := execLookPath("docker"); err != nil {
-		return errors.Wrap(err, "install docker cli to setup Google Artifact Registry access")
+		return errors.Wrap(err, `install "gcloud" to setup Google Artifact Registry access`)
 	}
 	// Create a temporary dir to hold a new docker config that lacks credsStore.
 	// Then use `docker login` to store the generated credentials directly in
@@ -388,9 +353,6 @@ func (k *KindSpec) setupGoogleArtifactRegistryAccess() error {
 }
 
 func (k *KindSpec) loadContainerImages() error {
-	if _, err := execLookPath("docker"); err != nil {
-		return errors.Wrap(err, "install docker cli to load container images")
-	}
 	for s, d := range k.ContainerImages {
 		log.Infof("Loading %q as %q", s, d)
 		if err := execer.Exec("docker", "pull", s); err != nil {

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -62,7 +62,7 @@ func TestKindSpec(t *testing.T) {
 			Name: "test",
 		},
 		execPathErr: true,
-		wantErr:     `install "kind" to deploy`,
+		wantErr:     `install dependency "kind" to deploy`,
 	}, {
 		desc: "create cluster fail",
 		k: &KindSpec{

--- a/deploy/deploy_test.go
+++ b/deploy/deploy_test.go
@@ -29,8 +29,6 @@ import (
 
 func TestKindSpec(t *testing.T) {
 	ctx := context.Background()
-	mockCtrl := gomock.NewController(t)
-	defer mockCtrl.Finish()
 
 	tests := []struct {
 		desc        string
@@ -38,7 +36,6 @@ func TestKindSpec(t *testing.T) {
 		execer      execerInterface
 		execPathErr bool
 		wantErr     string
-		mockExpects func(m *mocks.Mockprovider)
 	}{{
 		desc: "create cluster with cli",
 		k: &KindSpec{
@@ -46,69 +43,33 @@ func TestKindSpec(t *testing.T) {
 		},
 		execer: exec.NewFakeExecer(nil),
 	}, {
-		desc: "create cluster with client",
-		k: &KindSpec{
-			Name:             "test",
-			DeployWithClient: true,
-		},
-		mockExpects: func(m *mocks.Mockprovider) {
-			m.EXPECT().Create("test", gomock.Any()).Return(nil)
-		},
-	}, {
 		desc: "create cluster with recycle",
 		k: &KindSpec{
 			Name:    "test",
 			Recycle: true,
 		},
-		execer: exec.NewFakeExecer(nil),
-		mockExpects: func(m *mocks.Mockprovider) {
-			m.EXPECT().List().Return([]string{"test1"}, nil)
-		},
-	}, {
-		desc: "create cluster with recycle with client",
-		k: &KindSpec{
-			Name:             "test",
-			Recycle:          true,
-			DeployWithClient: true,
-		},
-		mockExpects: func(m *mocks.Mockprovider) {
-			m.EXPECT().Create("test", gomock.Any()).Return(nil)
-			m.EXPECT().List().Return([]string{"test1"}, nil)
-		},
+		execer: exec.NewFakeExecer(nil, nil),
 	}, {
 		desc: "exists cluster with recycle",
 		k: &KindSpec{
 			Name:    "test",
 			Recycle: true,
 		},
-		mockExpects: func(m *mocks.Mockprovider) {
-			m.EXPECT().List().Return([]string{"test"}, nil)
-		},
+		execer: exec.NewFakeExecer(nil),
 	}, {
 		desc: "unable to find kind cli",
 		k: &KindSpec{
 			Name: "test",
 		},
-		execer:      exec.NewFakeExecer(nil),
 		execPathErr: true,
-		wantErr:     "install kind cli to deploy",
+		wantErr:     `install "kind" to deploy`,
 	}, {
-		desc: "create cluster with cli fail",
+		desc: "create cluster fail",
 		k: &KindSpec{
 			Name: "test",
 		},
 		execer:  exec.NewFakeExecer(errors.New("cmd failed")),
-		wantErr: "failed to create cluster using cli",
-	}, {
-		desc: "create cluster with client fail",
-		k: &KindSpec{
-			Name:             "test",
-			DeployWithClient: true,
-		},
-		mockExpects: func(m *mocks.Mockprovider) {
-			m.EXPECT().Create("test", gomock.Any()).Return(fmt.Errorf("create failed"))
-		},
-		wantErr: "failed to create cluster using kind client",
+		wantErr: "failed to create cluster",
 	}, {
 		desc: "create cluster with GAR - 1 reg",
 		k: &KindSpec{
@@ -164,15 +125,6 @@ func TestKindSpec(t *testing.T) {
 		execer:  exec.NewFakeExecer(nil, nil, nil, nil, nil, errors.New("failed to restart kubelet")),
 		wantErr: "failed to restart kubelet",
 	}, {
-		desc: "create cluster with GAR - requires CLI",
-		k: &KindSpec{
-			Name:                     "test",
-			DeployWithClient:         true,
-			GoogleArtifactRegistries: []string{"us-west1-docker.pkg.dev"},
-		},
-		execer:  exec.NewFakeExecer(nil),
-		wantErr: "requires unsetting the deployWithClient field",
-	}, {
 		desc: "create cluster load containers",
 		k: &KindSpec{
 			Name: "test",
@@ -212,29 +164,11 @@ func TestKindSpec(t *testing.T) {
 		},
 		execer:  exec.NewFakeExecer(nil, nil, nil, errors.New("unable to load")),
 		wantErr: "loading",
-	}, {
-		desc: "create cluster load containers - requires CLI",
-		k: &KindSpec{
-			Name:             "test",
-			DeployWithClient: true,
-			ContainerImages: map[string]string{
-				"docker": "local",
-			},
-		},
-		execer:  exec.NewFakeExecer(nil),
-		wantErr: "requires unsetting the deployWithClient field",
 	}}
 	for _, tt := range tests {
 		t.Run(tt.desc, func(t *testing.T) {
-			m := mocks.NewMockprovider(mockCtrl)
-			if tt.mockExpects != nil {
-				tt.mockExpects(m)
-			}
 			if tt.execer != nil {
 				execer = tt.execer
-			}
-			newProvider = func() provider {
-				return m
 			}
 			execLookPath = func(_ string) (string, error) {
 				if tt.execPathErr {

--- a/topo/node/ceos/ceos.go
+++ b/topo/node/ceos/ceos.go
@@ -258,16 +258,16 @@ func defaults(pb *tpb.Node) *tpb.Node {
 	if pb.Services == nil {
 		pb.Services = map[uint32]*tpb.Service{
 			443: {
-				Name:     "ssl",
-				Inside:   443,
+				Name:   "ssl",
+				Inside: 443,
 			},
 			22: {
-				Name:     "ssh",
-				Inside:   22,
+				Name:   "ssh",
+				Inside: 22,
 			},
 			6030: {
-				Name:     "gnmi",
-				Inside:   6030,
+				Name:   "gnmi",
+				Inside: 6030,
 			},
 		}
 	}

--- a/topo/node/ceos/ceos_test.go
+++ b/topo/node/ceos/ceos_test.go
@@ -109,16 +109,16 @@ func TestNew(t *testing.T) {
 				},
 				Services: map[uint32]*topopb.Service{
 					443: {
-						Name:     "ssl",
-						Inside:   443,
+						Name:   "ssl",
+						Inside: 443,
 					},
 					22: {
-						Name:     "ssh",
-						Inside:   22,
+						Name:   "ssh",
+						Inside: 22,
 					},
 					6030: {
-						Name:     "gnmi",
-						Inside:   6030,
+						Name:   "gnmi",
+						Inside: 6030,
 					},
 				},
 			},
@@ -169,16 +169,16 @@ func TestNew(t *testing.T) {
 				},
 				Services: map[uint32]*topopb.Service{
 					443: {
-						Name:     "ssl",
-						Inside:   443,
+						Name:   "ssl",
+						Inside: 443,
 					},
 					22: {
-						Name:     "ssh",
-						Inside:   22,
+						Name:   "ssh",
+						Inside: 22,
 					},
 					6030: {
-						Name:     "gnmi",
-						Inside:   6030,
+						Name:   "gnmi",
+						Inside: 6030,
 					},
 				},
 			},

--- a/topo/node/cptx/cptx.go
+++ b/topo/node/cptx/cptx.go
@@ -344,16 +344,16 @@ func defaults(pb *tpb.Node) *tpb.Node {
 	if pb.Services == nil {
 		pb.Services = map[uint32]*tpb.Service{
 			443: {
-				Name:     "ssl",
-				Inside:   443,
+				Name:   "ssl",
+				Inside: 443,
 			},
 			22: {
-				Name:     "ssh",
-				Inside:   22,
+				Name:   "ssh",
+				Inside: 22,
 			},
 			50051: {
-				Name:     "gnmi",
-				Inside:   50051,
+				Name:   "gnmi",
+				Inside: 50051,
 			},
 		}
 	}

--- a/topo/node/cptx/cptx_test.go
+++ b/topo/node/cptx/cptx_test.go
@@ -193,16 +193,16 @@ func TestNew(t *testing.T) {
 			},
 			Services: map[uint32]*tpb.Service{
 				443: {
-					Name:     "ssl",
-					Inside:   443,
+					Name:   "ssl",
+					Inside: 443,
 				},
 				22: {
-					Name:     "ssh",
-					Inside:   22,
+					Name:   "ssh",
+					Inside: 22,
 				},
 				50051: {
-					Name:     "gnmi",
-					Inside:   50051,
+					Name:   "gnmi",
+					Inside: 50051,
 				},
 			},
 			Labels: map[string]string{
@@ -239,16 +239,16 @@ func TestNew(t *testing.T) {
 			},
 			Services: map[uint32]*tpb.Service{
 				443: {
-					Name:     "ssl",
-					Inside:   443,
+					Name:   "ssl",
+					Inside: 443,
 				},
 				22: {
-					Name:     "ssh",
-					Inside:   22,
+					Name:   "ssh",
+					Inside: 22,
 				},
 				50051: {
-					Name:     "gnmi",
-					Inside:   50051,
+					Name:   "gnmi",
+					Inside: 50051,
 				},
 			},
 			Labels: map[string]string{

--- a/topo/node/srl/srl.go
+++ b/topo/node/srl/srl.go
@@ -191,16 +191,16 @@ func defaults(pb *topopb.Node) *topopb.Node {
 	if pb.Services == nil {
 		pb.Services = map[uint32]*topopb.Service{
 			443: {
-				Name:    "ssl",
-				Inside:  443,
+				Name:   "ssl",
+				Inside: 443,
 			},
 			22: {
-				Name:     "ssh",
-				Inside:   22,
+				Name:   "ssh",
+				Inside: 22,
 			},
 			57400: {
-				Name:     "gnmi",
-				Inside:   57400,
+				Name:   "gnmi",
+				Inside: 57400,
 			},
 		}
 

--- a/topo/node/srl/srl_test.go
+++ b/topo/node/srl/srl_test.go
@@ -87,16 +87,16 @@ func TestNew(t *testing.T) {
 			},
 			Services: map[uint32]*topopb.Service{
 				443: {
-					Name:     "ssl",
-					Inside:   443,
+					Name:   "ssl",
+					Inside: 443,
 				},
 				22: {
-					Name:     "ssh",
-					Inside:   22,
+					Name:   "ssh",
+					Inside: 22,
 				},
 				57400: {
-					Name:     "gnmi",
-					Inside:   57400,
+					Name:   "gnmi",
+					Inside: 57400,
 				},
 			},
 		},


### PR DESCRIPTION
Before the dependency checking was not uniform, some methods checked for required binaries and others didn't.

Now "docker" and "kubectl" are considered dependencies to make any deployment

"kind" is a dependency to make deployments with kind cluster

"gcloud" is only a dependency when using kind linked with GAR

Other changes:
- removed kind provider deployment without kind cli (now that "kind" cli is a hard requirement, also some of the optional fields like gar support, container loading, deletion etc. were only compatible with cli deployment)
- recycle is now checked using kubectl instead of the kind provider
- clean up code in tests
- go fmt all of kne